### PR TITLE
Support Mac ARM64 and RaspberryPI ARMv7 and some more

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,5 +165,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ env.ADDITIONAL_TAG }}

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -215,6 +215,21 @@ docker run --rm karimz1/imgcompress --help
 ```
 
 ------
+## 🖥️ Supported Platforms
+This Docker image is built for the following platforms:
+
+✅ linux/amd64 (Intel/AMD x86_64 – Most Linux distros & Windows with WSL2)
+✅ linux/arm64 (Mac M1/M2, AWS Graviton)
+✅ linux/arm/v7 (Raspberry Pi, 32-bit ARM)
+✅ Windows (via WSL2 with Linux containers enabled)
+❌ linux/ppc64le and linux/s390x are not supported due to dependency limitations, but for real who uses it today 🤔.
+
+### 💡 Windows Support:
+This image runs on Windows when Docker Desktop is set to use WSL2 and Linux containers. No native Windows container support is needed.
+
+By default, the Docker image is built for linux/amd64, linux/arm64, and linux/arm/v7 to ensure broad compatibility.
+
+------
 
 ## 🔒 Privacy & Security
 


### PR DESCRIPTION
I just noticed mac was not supported, so I fixed it!

```shell
❯ docker pull karimz1/imgcompress:latest
Error response from daemon: no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found

```


## 🖥️ Supported Platforms
This Docker image is built for the following platforms:

✅ linux/amd64 (Intel/AMD x86_64 – Most Linux distros & Windows with WSL2)
✅ linux/arm64 (Mac M1/M2, AWS Graviton)
✅ linux/arm/v7 (Raspberry Pi, 32-bit ARM)
✅ Windows (via WSL2 with Linux containers enabled)
❌ linux/ppc64le and linux/s390x are not supported due to dependency limitations, but for real who uses it today 🤔.

### 💡 Windows Support:
This image runs on Windows when Docker Desktop is set to use WSL2 and Linux containers. No native Windows container support is needed.

By default, the Docker image is built for linux/amd64, linux/arm64, and linux/arm/v7 to ensure broad compatibility.