### PR TITLE
Configures Dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,29 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/" 
+    directories:
+      - "/"
+      - "/.devcontainer"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
+      interval: "weekly"
+    open-pull-requests-limit: 20
+    labels: ["dependencies"]
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/.devcontainer"
+    schedule:
+      interval: "weekly"
 
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
+      interval: "weekly"
+    open-pull-requests-limit: 20
+    labels: ["dependencies"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Sets up Dependabot to automatically create pull requests for dependency updates in various package ecosystems (pip, docker, npm, and github-actions).

Changes the update schedule from daily to weekly to reduce the frequency of pull requests. Increases the open pull request limit for pip and npm dependencies.