### PR TITLE
Refactors devcontainer to use pre-built image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM ghcr.io/karimz1/devcontainer-image-only-for-devs@sha256:1466f80cb21f351d42664f270faa7182aa6e3eece12dba23a3633168f3785e4c
+  
+# Python virtual environment  
+WORKDIR /app  
+RUN python3 -m venv /venv  
+ENV PATH="/venv/bin:$PATH"  
+  
+# Install Python dependencies  
+COPY requirements-dev.txt .  
+RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements-dev.txt  
+  
+  
+ENTRYPOINT ["/bin/sh"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
    "name": "Image Compressor DevContainer",
-   "image": "ghcr.io/karimz1/devcontainer-image-only-for-devs:2025-07",
+   "image": "ghcr.io/karimz1/devcontainer-image-only-for-devs@sha256:1466f80cb21f351d42664f270faa7182aa6e3eece12dba23a3633168f3785e4c",
    "postCreateCommand": "pip install -r .devcontainer/requirements-dev.txt && pnpm install --dir frontend/ && echo 'Dev container is ready!'",
     "containerEnv": {
       "IS_RUNNING_IN_DEVCONTAINER": "true"


### PR DESCRIPTION
Streamlines the development container setup by utilizing a pre-built image from GitHub Container Registry. This eliminates the need for building the container locally, resulting in:

- Faster setup times for new developers
- Consistent development environment
- Automated deployment of the devcontainer image every 2 months through a CI workflow.
- Removes the local Dockerfile.
- Adds a base Dockerfile which is used in CI.
- Enforces LF line endings for consistency across platforms with `.gitattributes` file.