### PR TITLE
Release/0.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
 #
 # Together, these libraries ensure Pillow (PIL) can handle nearly every major image type used in production.
 # But I haven't tested all in CI, yet.
-RUN apt-get update --allow-releaseinfo-change || apt-get update --allow-insecure-repositories; \
-    apt-get install -y --no-install-recommends --allow-unauthenticated \
+RUN apt-get update --allow-releaseinfo-change -o Acquire::Retries=5 -o Acquire::http::Timeout=30; \
+    apt-get install -y --no-install-recommends \
     python3-dev python3-pip \
     libjpeg-dev libpng-dev libtiff-dev libwebp-dev libopenjp2-7-dev \
     libimagequant-dev libheif-dev liblcms2-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
 #
 # Together, these libraries ensure Pillow (PIL) can handle nearly every major image type used in production.
 # But I haven't tested all in CI, yet.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update --allow-releaseinfo-change || apt-get update --allow-insecure-repositories; \
+    apt-get install -y --no-install-recommends --allow-unauthenticated \
     python3-dev python3-pip \
     libjpeg-dev libpng-dev libtiff-dev libwebp-dev libopenjp2-7-dev \
     libimagequant-dev libheif-dev liblcms2-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
 #
 # Together, these libraries ensure Pillow (PIL) can handle nearly every major image type used in production.
 # But I haven't tested all in CI, yet.
-RUN apt-get update --allow-releaseinfo-change -o Acquire::Retries=5 -o Acquire::http::Timeout=30; \
+RUN set -eux; \
+    apt-get update -o Acquire::Retries=5 -o Acquire::http::Timeout=30 && \
     apt-get install -y --no-install-recommends \
     python3-dev python3-pip \
     libjpeg-dev libpng-dev libtiff-dev libwebp-dev libopenjp2-7-dev \

--- a/frontend/public/release-notes.md
+++ b/frontend/public/release-notes.md
@@ -1,3 +1,7 @@
+## v0.6.1 — 2026-04-17
+- Feature: Add GitHub Star Banner to Compressed Files Drawer[#599](https://github.com/karimz1/imgcompress/issues/599)
+- Internal: Update Dependencies.
+
 ## v0.6.0 — 2026-01-22
 - Feature: Enhanced Image to PDF Export: Multi-Page Formatting and Page Controls [#476](https://github.com/karimz1/imgcompress/issues/476)
 - Feature: Search and Filter for Supported Formats Dialog [#477](https://github.com/karimz1/imgcompress/issues/477)

--- a/frontend/public/release-notes.md
+++ b/frontend/public/release-notes.md
@@ -1,6 +1,6 @@
-## v0.6.1 — 2026-04-17
-- Feature: Add GitHub Star Banner to Compressed Files Drawer[#599](https://github.com/karimz1/imgcompress/issues/599)
-- Internal: Update Dependencies.
+## v0.6.1 — 2026-04-18
+- Feature: Add GitHub Star Banner to Compressed Files Drawer [#599](https://github.com/karimz1/imgcompress/issues/599)
+- Update Dependencies: This update brings all dependencies to the latest release candidates available at the time, improving security, stability, and overall reliability for imgcompress.
 
 ## v0.6.0 — 2026-01-22
 - Feature: Enhanced Image to PDF Export: Multi-Page Formatting and Page Controls [#476](https://github.com/karimz1/imgcompress/issues/476)

--- a/frontend/public/release-notes.md
+++ b/frontend/public/release-notes.md
@@ -1,3 +1,7 @@
+## v0.6.1 — 2026-04-18
+- Stability Improvement: Improved Debian Bookworm Docker build reliability by adding apt-get retry and timeout handling. PR by[Lilyandlucy](https://github.com/karimz1/imgcompress/pull/532)
+
+
 ## v0.6.0 — 2026-01-22
 - Feature: Enhanced Image to PDF Export: Multi-Page Formatting and Page Controls [#476](https://github.com/karimz1/imgcompress/issues/476)
 - Feature: Search and Filter for Supported Formats Dialog [#477](https://github.com/karimz1/imgcompress/issues/477)

--- a/frontend/src/components/CompressedFilesDrawer.tsx
+++ b/frontend/src/components/CompressedFilesDrawer.tsx
@@ -15,6 +15,7 @@ import {
 import { pluralize } from "@/lib/helpers";
 import { toast, ToastContainer } from "react-toastify";
 import { FileDown } from "lucide-react";
+import GitHubStarBanner from "@/components/GitHubStarBanner";
 
 interface CompressedFilesDrawerProps {
   converted: string[];
@@ -68,6 +69,7 @@ const CompressedFilesDrawer: React.FC<CompressedFilesDrawerProps> = ({
               Download your compressed {pluralize(converted.length, "Image", "Images")} individually or all at once.
             </DrawerDescription>
           </DrawerHeader>
+          <GitHubStarBanner compressionId={converted.join(",")} />
           <div className="p-1 pb-0 flex flex-col items-center">
             {converted.length > 1 && (
               <div className="text-center p-5">

--- a/frontend/src/components/GitHubStarBanner.tsx
+++ b/frontend/src/components/GitHubStarBanner.tsx
@@ -46,7 +46,7 @@ const GitHubStarBanner: React.FC<GitHubStarBannerProps> = ({ compressionId }) =>
   if (!visible) return null;
 
   return (
-    <div className="mx-4 mt-3 rounded-lg border border-amber-200/50 bg-amber-50/40 px-4 py-3 dark:border-amber-500/15 dark:bg-amber-500/5">
+    <div data-testid="github-star-banner" className="mx-4 mt-3 rounded-lg border border-amber-200/50 bg-amber-50/40 px-4 py-3 dark:border-amber-500/15 dark:bg-amber-500/5">
       <div className="flex items-start gap-3">
         <Star className="mt-0.5 h-3.5 w-3.5 shrink-0 fill-amber-400 text-amber-400" />
         <div className="min-w-0 flex-1">
@@ -63,6 +63,7 @@ const GitHubStarBanner: React.FC<GitHubStarBannerProps> = ({ compressionId }) =>
             helps others discover it.
           </p>
           <button
+            data-testid="github-star-banner-dismiss-btn"
             onClick={dismiss}
             className="mt-1 text-xs text-slate-400 underline underline-offset-2 transition-colors hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-400"
           >

--- a/frontend/src/components/GitHubStarBanner.tsx
+++ b/frontend/src/components/GitHubStarBanner.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Star } from "lucide-react";
+import { APP_CONFIG } from "@/lib/config";
+
+const DISMISSED_KEY = "imgcompress_github_star_dismissed";
+const CONVERSIONS_KEY = "imgcompress_conversion_count";
+const LAST_COMPRESSION_KEY = "imgcompress_last_compression_id";
+
+interface GitHubStarBannerProps {
+  compressionId: string;
+}
+
+const GitHubStarBanner: React.FC<GitHubStarBannerProps> = ({ compressionId }) => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!compressionId) return;
+    try {
+      const dismissed = localStorage.getItem(DISMISSED_KEY);
+      if (dismissed) return;
+
+      let total = parseInt(localStorage.getItem(CONVERSIONS_KEY) ?? "0", 10);
+
+      const lastId = sessionStorage.getItem(LAST_COMPRESSION_KEY);
+      if (lastId !== compressionId) {
+        sessionStorage.setItem(LAST_COMPRESSION_KEY, compressionId);
+        total += 1;
+        localStorage.setItem(CONVERSIONS_KEY, String(total));
+      }
+
+      if (total >= 2) setVisible(true);
+    } catch {
+    }
+  }, [compressionId]);
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(DISMISSED_KEY, "1");
+    } catch {
+    }
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="mx-4 mt-3 rounded-lg border border-amber-200/50 bg-amber-50/40 px-4 py-3 dark:border-amber-500/15 dark:bg-amber-500/5">
+      <div className="flex items-start gap-3">
+        <Star className="mt-0.5 h-3.5 w-3.5 shrink-0 fill-amber-400 text-amber-400" />
+        <div className="min-w-0 flex-1">
+          <p className="text-xs text-slate-600 dark:text-slate-400">
+            Found ImgCompress useful?{" "}
+            <a
+              href={APP_CONFIG.GITHUB_REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-slate-800 underline underline-offset-2 transition-colors hover:text-slate-900 dark:text-slate-200 dark:hover:text-white"
+            >
+              A star on GitHub
+            </a>{" "}
+            helps others discover it.
+          </p>
+          <button
+            onClick={dismiss}
+            className="mt-1 text-xs text-slate-400 underline underline-offset-2 transition-colors hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-400"
+          >
+            Don&apos;t show again
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GitHubStarBanner;

--- a/frontend/tests/e2e/gitHubStarBanner_Test.spec.ts
+++ b/frontend/tests/e2e/gitHubStarBanner_Test.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect, Page } from '@playwright/test';
+import {
+  uploadFilesToDropzoneAsync,
+  clickConversionButtonAsync,
+  assertCloseDrawerBtnClickAsync,
+  setOutputFormatAsync,
+} from './utls/helpers';
+import { ImageFileDto } from './utls/ImageFileDto';
+
+const DISMISSED_KEY = 'imgcompress_github_star_dismissed';
+const CONVERSIONS_KEY = 'imgcompress_conversion_count';
+
+const fileA = new ImageFileDto('pexels-pealdesign-28594392.jpg');
+const fileB = new ImageFileDto('pexels-willianjusten-29944187.jpg');
+
+async function compressFileAsync(page: Page, file: ImageFileDto): Promise<void> {
+  await setOutputFormatAsync(page, 'JPEG');
+  await uploadFilesToDropzoneAsync(page, [file]);
+  await clickConversionButtonAsync(page);
+}
+
+test.describe('GitHub Star Banner', () => {
+  test('is not shown on the first compression', async ({ page }) => {
+    await page.goto('/');
+    await compressFileAsync(page, fileA);
+
+    await expect(page.getByTestId('github-star-banner')).not.toBeVisible();
+  });
+
+  test('is shown on the second compression in the same session using a different file', async ({ page }) => {
+    await page.goto('/');
+    await compressFileAsync(page, fileA);
+    await expect(page.getByTestId('github-star-banner')).not.toBeVisible();
+
+    await assertCloseDrawerBtnClickAsync(page);
+
+    await compressFileAsync(page, fileB);
+    await expect(page.getByTestId('github-star-banner')).toBeVisible();
+  });
+
+  test('is shown on the second session with the same file', async ({ page }) => {
+    await page.goto('/');
+    await compressFileAsync(page, fileA);
+    await expect(page.getByTestId('github-star-banner')).not.toBeVisible();
+
+    // Simulate a new session by clearing sessionStorage (same as closing and reopening the tab)
+    await page.evaluate(() => sessionStorage.clear());
+    await page.goto('/');
+
+    await compressFileAsync(page, fileA);
+    await expect(page.getByTestId('github-star-banner')).toBeVisible();
+  });
+
+  test('opening and closing the drawer multiple times does not trigger the banner early', async ({ page }) => {
+    await page.goto('/');
+    await compressFileAsync(page, fileA);
+    await expect(page.getByTestId('github-star-banner')).not.toBeVisible();
+
+    await assertCloseDrawerBtnClickAsync(page);
+    await page.getByRole('button', { name: /Show Compressed/i }).click();
+    await expect(page.getByTestId('github-star-banner')).not.toBeVisible();
+
+    await assertCloseDrawerBtnClickAsync(page);
+    await page.getByRole('button', { name: /Show Compressed/i }).click();
+    await expect(page.getByTestId('github-star-banner')).not.toBeVisible();
+  });
+
+  test('dismissing hides the banner permanently across page reloads', async ({ page }) => {
+    await page.goto('/');
+    // Pre-seed count=1 so the next compression pushes it to 2 and triggers the banner
+    await page.evaluate((key) => localStorage.setItem(key, '1'), CONVERSIONS_KEY);
+
+    await compressFileAsync(page, fileA);
+    const banner = page.getByTestId('github-star-banner');
+    await expect(banner).toBeVisible();
+
+    await page.getByTestId('github-star-banner-dismiss-btn').click();
+    await expect(banner).not.toBeVisible();
+
+    // Reload and compress again — banner must stay hidden
+    await page.evaluate(() => sessionStorage.clear());
+    await page.goto('/');
+    await compressFileAsync(page, fileA);
+    await expect(page.getByTestId('github-star-banner')).not.toBeVisible();
+
+    const dismissed = await page.evaluate((key) => localStorage.getItem(key), DISMISSED_KEY);
+    expect(dismissed).toBe('1');
+  });
+});


### PR DESCRIPTION
# v0.6.1 — 2026-04-18

- Feature: Add GitHub Star Banner to Compressed Files Drawer [#599](https://github.com/karimz1/imgcompress/issues/599)
- Update Dependencies: This update brings all dependencies to the latest release candidates available at the time, improving security, stability, and overall reliability for imgcompress.
- Stability Improvement: Improved Debian Bookworm Docker build reliability by adding apt-get retry and timeout handling. PR by [Lilyandlucy](https://github.com/karimz1/imgcompress/pull/532)
