### PR TITLE
feat(pdf): reject oversized pages before rendering

### DIFF
--- a/backend/image_converter/application/payload_expander_factory.py
+++ b/backend/image_converter/application/payload_expander_factory.py
@@ -1,10 +1,17 @@
-from backend.image_converter.application.file_payload_expander import FilePayloadExpander
+from backend.image_converter.application.file_payload_expander import (
+    FilePayloadExpander,
+)
+from backend.image_converter.config import settings
+from backend.image_converter.infrastructure.logger import Logger
 from backend.image_converter.infrastructure.pdf_page_extractor import PdfPageExtractor
 from backend.image_converter.infrastructure.psd_renderer import PsdRenderer
-from backend.image_converter.infrastructure.logger import Logger
 
 
 def create_payload_expander(logger: Logger) -> FilePayloadExpander:
-    pdf_extractor = PdfPageExtractor(logger=logger)
+    pdf_config = settings.get().pdf
+    pdf_extractor = PdfPageExtractor(
+        logger=logger,
+        max_render_pixels_per_page=pdf_config.max_render_pixels_per_page,
+    )
     psd_renderer = PsdRenderer(logger=logger)
     return FilePayloadExpander(pdf_extractor, psd_renderer)

--- a/backend/image_converter/config/app.json
+++ b/backend/image_converter/config/app.json
@@ -34,6 +34,9 @@
       ".psd"
     ]
   },
+  "pdf": {
+    "max_render_pixels_per_page": 25000000
+  },
   "features": {
     "is_storage_management_enabled": true,
     "is_logo_enabled": true,

--- a/backend/image_converter/config/app_config.py
+++ b/backend/image_converter/config/app_config.py
@@ -51,6 +51,11 @@ class FormatsConfig:
 
 
 @dataclass(frozen=True)
+class PdfConfig:
+    max_render_pixels_per_page: int
+
+
+@dataclass(frozen=True)
 class FeaturesConfig:
     is_storage_management_enabled: bool
     is_logo_enabled: bool
@@ -70,5 +75,6 @@ class AppConfig:
     logging: LoggingConfig
     crop_preview: CropPreviewConfig
     formats: FormatsConfig
+    pdf: PdfConfig
     features: FeaturesConfig
     rembg: RembgConfig

--- a/backend/image_converter/config/loader.py
+++ b/backend/image_converter/config/loader.py
@@ -19,12 +19,12 @@ from backend.image_converter.config.app_config import (
     FeaturesConfig,
     FormatsConfig,
     LoggingConfig,
+    PdfConfig,
     RembgConfig,
     TemporaryStorageConfig,
     UploadsConfig,
     WebConfig,
 )
-
 from backend.image_converter.domain.web_workers import WebWorkerCount
 
 
@@ -67,6 +67,9 @@ def load_from_file(path: Path) -> AppConfig:
     errors: list[str] = []
     reader = _Reader(raw, errors)
 
+    if "pdf" in raw and not isinstance(raw["pdf"], dict):
+        errors.append("config key 'pdf' must be an object")
+
     temp_storage = TemporaryStorageConfig(
         directory=reader.require_str(("temporary_storage", "directory")),
         max_age_seconds=reader.require_int(("temporary_storage", "max_age_seconds"), minimum=1),
@@ -99,6 +102,13 @@ def load_from_file(path: Path) -> AppConfig:
             ("formats", "custom_pipeline_extensions"),
         ),
     )
+    pdf = PdfConfig(
+        max_render_pixels_per_page=reader.optional_int(
+            ("pdf", "max_render_pixels_per_page"),
+            default=25_000_000,
+            minimum=1,
+        ),
+    )
     features = FeaturesConfig(
         is_storage_management_enabled=reader.require_feature_flag(
             ("features", "is_storage_management_enabled"),
@@ -122,6 +132,7 @@ def load_from_file(path: Path) -> AppConfig:
         logging=logging_cfg,
         crop_preview=crop_preview,
         formats=formats,
+        pdf=pdf,
         features=features,
         rembg=rembg,
     )

--- a/backend/image_converter/infrastructure/pdf_page_extractor.py
+++ b/backend/image_converter/infrastructure/pdf_page_extractor.py
@@ -1,9 +1,10 @@
-from io import BytesIO
+import math
 import traceback
+from io import BytesIO
 from typing import Any, Optional
 
-from backend.image_converter.infrastructure.logger import Logger
 from backend.image_converter.core.internals.utilities import Result
+from backend.image_converter.infrastructure.logger import Logger
 
 
 class PdfPageExtractor:
@@ -12,10 +13,17 @@ class PdfPageExtractor:
     processed by the existing image pipeline.
     """
 
-    def __init__(self, logger: Optional[Logger] = None, dpi: int = 300, image_format: str = "PNG"):
+    def __init__(
+        self,
+        logger: Optional[Logger] = None,
+        dpi: int = 300,
+        image_format: str = "PNG",
+        max_render_pixels_per_page: int = 25_000_000,
+    ):
         self.logger = logger
         self.dpi = dpi
         self.image_format = image_format
+        self.max_render_pixels_per_page = max_render_pixels_per_page
 
     def rasterize_pages(self, pdf_bytes: bytes, source_hint: str = "") -> Result[Any]:
         """
@@ -23,7 +31,15 @@ class PdfPageExtractor:
         """
         try:
             document = self._open_document(pdf_bytes)
-            
+            try:
+                validation_error = self._validate_page_sizes(document)
+            except Exception:
+                document.close()
+                raise
+            if validation_error:
+                document.close()
+                return Result.failure(validation_error)
+
             def page_generator():
                 try:
                     scale = self._dpi_to_scale()
@@ -32,7 +48,7 @@ class PdfPageExtractor:
                         yield self._render_single_page(page, scale)
                 finally:
                     document.close()
-            
+
             return Result.success(page_generator())
         except Exception:
             self._log_failure(traceback.format_exc(), source_hint)
@@ -56,6 +72,21 @@ class PdfPageExtractor:
 
     def _dpi_to_scale(self) -> float:
         return self.dpi / 72.0
+
+    def _validate_page_sizes(self, document: Any) -> Optional[str]:
+        scale = self._dpi_to_scale()
+        for page_index in range(len(document)):
+            width, height = document.get_page_size(page_index)
+            width_pixels = math.ceil(width * scale)
+            height_pixels = math.ceil(height * scale)
+            page_pixels = width_pixels * height_pixels
+            if page_pixels > self.max_render_pixels_per_page:
+                return (
+                    f"PDF page {page_index + 1} exceeds the maximum allowed "
+                    f"rendered pixel count ({self.max_render_pixels_per_page})."
+                )
+
+        return None
 
     def _log_failure(self, traceback_text: str, source_hint: str) -> None:
         if not self.logger:

--- a/tests/unit/test_pdf_support.py
+++ b/tests/unit/test_pdf_support.py
@@ -2,13 +2,15 @@ from io import BytesIO
 
 from PIL import Image
 
+from backend.image_converter.application.file_payload_expander import (
+    FilePayloadExpander,
+)
 from backend.image_converter.config import settings
 from backend.image_converter.core.internals.utilities import (
     Result,
     supported_extensions,
 )
 from backend.image_converter.infrastructure.pdf_page_extractor import PdfPageExtractor
-from backend.image_converter.application.file_payload_expander import FilePayloadExpander
 
 SAMPLE_PDF = "tests/sample-images/imgcompress_screenshot.pdf"
 
@@ -57,6 +59,58 @@ def test_When_PdfiumRaisesRuntimeError_Expect_ExtractorFailure(monkeypatch):
         "boom" in message and "broken.pdf" in message
         for message, _ in logger.messages
     )
+
+
+class _FakePdfPage:
+    def __init__(self, render_calls):
+        self.render_calls = render_calls
+
+    def render(self, scale):
+        self.render_calls.append(scale)
+        return self
+
+    def to_pil(self):
+        return Image.new("RGB", (1, 1))
+
+    def close(self):
+        pass
+
+
+class _FakePdfDocument:
+    def __init__(self, page_sizes):
+        self.page_sizes = page_sizes
+        self.render_calls = []
+        self.pages = [_FakePdfPage(self.render_calls) for _ in page_sizes]
+        self.closed = False
+
+    def __len__(self):
+        return len(self.pages)
+
+    def __getitem__(self, index):
+        return self.pages[index]
+
+    def get_page_size(self, index):
+        return self.page_sizes[index]
+
+    def close(self):
+        self.closed = True
+
+
+def test_When_PdfContains20InchPage_Expect_RejectedBeforeRendering(monkeypatch):
+    twenty_inches_in_points = 20 * 72
+    document = _FakePdfDocument(
+        page_sizes=[(twenty_inches_in_points, twenty_inches_in_points)]
+    )
+    monkeypatch.setattr(PdfPageExtractor, "_open_document", lambda *_: document)
+
+    result = PdfPageExtractor().rasterize_pages(b"pdf", "large-page.pdf")
+
+    assert result.is_successful is False
+    assert result.error == (
+        "PDF page 1 exceeds the maximum allowed rendered pixel count (25000000)."
+    )
+    assert document.render_calls == []
+    assert document.closed is True
 
 
 class DummyRenderer:

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -24,7 +24,6 @@ from backend.image_converter.config.loader import ConfigError, load_from_file
 from backend.image_converter.domain.units import BYTES_PER_MEBIBYTE
 from backend.image_converter.domain.web_workers import WebWorkerCount
 
-
 VALID_CONFIG = {
     "temporary_storage": {"directory": "/tmp", "max_age_seconds": 3600},
     "uploads": {"max_file_size_mebibytes": 40960},
@@ -39,6 +38,9 @@ VALID_CONFIG = {
         "unsupported_input_extensions": [".pdf", ".svg", ".raw"],
     },
     "formats": {"custom_pipeline_extensions": [".pdf", ".psd"]},
+    "pdf": {
+        "max_render_pixels_per_page": 25000000,
+    },
     "features": {
         "is_storage_management_enabled": True,
         "is_logo_enabled": True,
@@ -89,6 +91,7 @@ def test_valid_config_loads_into_typed_app_config(config_file):
     assert config.logging.max_size_bytes == 25 * BYTES_PER_MEBIBYTE
     assert config.crop_preview.max_retry_attempts == 3
     assert config.crop_preview.unsupported_input_extensions == (".pdf", ".svg", ".raw")
+    assert config.pdf.max_render_pixels_per_page == 25000000
     assert config.features.is_storage_management_enabled is True
     assert config.features.is_logo_enabled is True
     assert config.features.is_dev_mode_enabled is False
@@ -158,6 +161,23 @@ def test_logging_size_and_backups_default_when_omitted(config_file):
     assert logging_cfg.max_size_bytes == 25 * BYTES_PER_MEBIBYTE
 
 
+def test_pdf_render_pixel_limit_defaults_when_pdf_config_is_omitted(config_file):
+    cfg = _copy_config()
+    del cfg["pdf"]
+    config_file(cfg)
+
+    assert settings.get().pdf.max_render_pixels_per_page == 25_000_000
+
+
+def test_pdf_config_must_be_an_object(config_file):
+    cfg = _copy_config()
+    cfg["pdf"] = None
+    config_file(cfg)
+
+    with pytest.raises(ConfigError, match="config key 'pdf' must be an object"):
+        settings.get()
+
+
 @pytest.mark.parametrize(
     ("path", "bad_value", "message"),
     [
@@ -170,6 +190,7 @@ def test_logging_size_and_backups_default_when_omitted(config_file):
         (("crop_preview", "unsupported_input_extensions"), ".pdf", "must be a list"),
         (("logging", "max_size_mebibytes"), "25", "integer"),
         (("logging", "backup_count"), True, "integer"),
+        (("pdf", "max_render_pixels_per_page"), True, "integer"),
     ],
 )
 def test_invalid_value_types_are_rejected(config_file, path, bad_value, message):
@@ -190,6 +211,7 @@ def test_invalid_value_types_are_rejected(config_file, path, bad_value, message)
         (("crop_preview", "max_retry_attempts"), 0, ">= 1"),
         (("logging", "max_size_mebibytes"), 0, ">= 1"),
         (("logging", "backup_count"), -1, ">= 0"),
+        (("pdf", "max_render_pixels_per_page"), 0, ">= 1"),
     ],
 )
 def test_out_of_range_values_are_rejected(config_file, path, bad_value, message):


### PR DESCRIPTION
# Reject PDFs with Oversized Pages Before Rasterization

Closes #798

## Summary

This PR adds a configurable limit that rejects PDF pages with excessively large rendered dimensions before rasterization.

PDF rendering cost is determined by the page dimensions specified in the document rather than by the PDF file size. Previously, pages were rendered at 300 DPI without validating their expected pixel count, allowing small PDF files to generate very large bitmaps and consume significant CPU and memory.

## Changes

After opening a PDF, the implementation now calculates the expected rendered pixel count at 300 DPI for each page.

If any page exceeds the configured limit:

* Processing is aborted before `page.render()` is called.
* The PDF document is closed.
* An error identifying the page and configured limit is returned.

The limit can be configured in `app.json`:

```json
"pdf": {
  "max_render_pixels_per_page": 25000000
}
```

The default value is 25,000,000 pixels, equivalent to a 5,000 × 5,000 pixel image.

For comparison, a 20 × 20 inch PDF page is rendered at approximately 6,000 × 6,000 pixels at 300 DPI, or 36,000,000 pixels, and is therefore rejected by the default limit.

Common PDF page sizes such as A4 and Letter remain below the limit.

When the limit is exceeded, the following error is returned:

```text
PDF page 1 exceeds the maximum allowed rendered pixel count (25000000).
```

## Tests

The following cases are covered:

* Pages exceeding the limit are rejected before rendering.
* `page.render()` is not called for rejected pages.
* The PDF document is closed when processing is rejected.
* The default value is used when the `pdf` configuration is omitted.
* The type and range of the configured value are validated.
* Invalid configuration sections, including `pdf: null`, are rejected.
* Existing PDF processing continues to work.
* Lazy imports continue to work.

```text
44 passed
```

## Verification PDF

The following command generates a 100-page PDF with 20 × 20 inch pages:

```sh
/usr/bin/gs -q -dBATCH -dNOPAUSE \
  -sDEVICE=pdfwrite \
  -dDEVICEWIDTHPOINTS=1440 \
  -dDEVICEHEIGHTPOINTS=1440 \
  -dFIXEDMEDIA \
  -sOutputFile=oversized-100pages.pdf \
  -c "<</PageSize [1440 1440]>> setpagedevice 100 { showpage } repeat"
```

Because 1,440 points is equivalent to 20 inches, each page is rendered at approximately 6,000 × 6,000 pixels at 300 DPI.

The generated file can be inspected with:

```sh
pdfinfo oversized-100pages.pdf |
  grep -E 'Pages|Page size|File size'
```

## Out of Scope

This PR only limits the expected rendered pixel count per page.

Under the current API behavior, exceeding the limit still results in an HTTP 500 response. HTTP status classification and dedicated frontend error handling will need to be addressed in a separate change.
