### PR TITLE
chore(docker): refresh 2 DHI base image digests (fixes CVE-2026-45447)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN pnpm run build
 # Intent: Fallback to debian-base:trixie-debian13-dev because dhi.io/python:3.11-debian13 is 
 # currently affected by CVE-2026-6100 (CVSS 9.1) without an upstream patch.
 # Ref: https://scout.docker.com/vulnerabilities/id/CVE-2026-6100
-FROM dhi.io/debian-base:trixie-debian13-dev@sha256:41cc0e62bbb3b8cbb29deb40c987e55577cf98c4d00ede32b40159a1a4d87565 AS backend-build-stage
+FROM dhi.io/debian-base:trixie-debian13-dev@sha256:4440cf16b142316744a7fd1c5070eb23df54c7c335d8684c8d72864f0f3eb30e AS backend-build-stage
 
 # Use 'uv' for high-performance Python package management instead of standard pip.
 # Ref: https://github.com/astral-sh/uv
@@ -157,7 +157,7 @@ RUN mkdir -p /container/backend/image_converter/presentation/web/static_site
 
 # Stage 3: FINAL RUNTIME
 # ------------------------------------------------------------------------------------------
-FROM dhi.io/debian-base:trixie-debian13@sha256:436787c2d77ed1ef1cfe3ce5848f3968244d8948463a29094e1e672da9a6fa24 AS final-stage
+FROM dhi.io/debian-base:trixie-debian13@sha256:014bacad6433af5bc9bd098ac713c4f104f9b395dd1d9d58bbcafd51ad2ce582 AS final-stage
 
 LABEL org.opencontainers.image.authors="Karim Zouine <mails.karimzouine@gmail.com>" \
       org.opencontainers.image.vendor="Karim Zouine" \


### PR DESCRIPTION
Refresh of the pinned DHI base image digests. This is the branch the nightly `refresh-dockerfile-digests` workflow has been pushing every day, which never got a PR (see below).

| Image | From | To |
| --- | --- | --- |
| `dhi.io/debian-base:trixie-debian13-dev` | `sha256:41cc0e62…` | `sha256:4440cf16…` |
| `dhi.io/debian-base:trixie-debian13` | `sha256:436787c2…` | `sha256:014bacad…` |

## What this fixes

`CVE-2026-45447` (HIGH), OpenSSL heap use-after-free in `PKCS7_verify()`, affecting `libssl3t64`, `openssl` and `openssl-provider-legacy`.

- Installed on `main`: `3.5.6-1~deb13u1+dhi2`
- Fixed in: `3.5.6-1~deb13u2`

The new base moves Debian 13.5 to 13.6, which carries the patch.

## Verified

Trivy 0.70.0 (`--scanners vuln --severity HIGH,CRITICAL --ignore-unfixed`) run against both base image digests directly:

| Base | Result |
| --- | --- |
| `sha256:436787c2…` (on `main`) | `Total: 3 (HIGH: 3, CRITICAL: 0)`, exit 1 |
| `sha256:014bacad…` (this branch) | no findings, exit 0 |

This was the only vulnerability in the image. The Python dependency scan already reported 0.

## Why this needed opening by hand

The nightly workflow has failed every run for at least 5 days, always at the same step:

```
could not add label: 'docker-dependencies-update' not found
##[error]Process completed with exit code 1
```

`gh pr create --label` fails hard on a label that does not exist. The digest lookup and the branch push both succeeded, so the fix has been sitting on `chan/refresh-dockerfile-digests` unmerged the whole time. The label now exists, and a follow-up PR makes the workflow resilient so a missing label cannot silently stop security patches again.