### PR TITLE
fix(ci): unblock the nightly base image patch flow and scan the published image

### DIFF
--- a/.github/workflows/nightly-container-cve-scan.yml
+++ b/.github/workflows/nightly-container-cve-scan.yml
@@ -1,0 +1,129 @@
+name: Nightly container CVE scan
+
+# Scans the PUBLISHED image, which is what users actually run.
+#
+# The CI Trivy step only covers images built from a PR or a push, and it is
+# `continue-on-error` with the report tucked into an artifact nobody opens. That
+# leaves two gaps this workflow closes:
+#
+#   1. A CVE disclosed against an already-published image surfaces without any
+#      code change, so nothing in CI would ever run and notice it.
+#   2. Findings were invisible. Results now upload as SARIF and appear in the
+#      Security tab next to the CodeQL alerts.
+#
+# Remediation itself stays with `refresh-dockerfile-digests.yml`: base image CVEs
+# are fixed by DHI rebuilding the image, which moves the digest and opens a PR.
+# This workflow is the detector, so a broken or lagging refresh becomes visible
+# instead of silent.
+#
+# Runs after the 04:00 digest refresh so a fix landed overnight is reflected.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Image reference to scan"
+        required: false
+        default: "docker.io/karimz1/imgcompress:latest"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-container-cve-scan
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    name: Scan published image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Pull image under scan
+        env:
+          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:latest' }}
+        run: |
+          set -euo pipefail
+          echo "Scanning ${IMAGE_REF}"
+          docker pull "$IMAGE_REF"
+
+      # SARIF first, and never fail on it, so the Security tab is updated even
+      # when the run is about to be marked failed by the gate below.
+      - name: Produce SARIF report
+        env:
+          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:latest' }}
+          SCAN_OUTPUT: trivy-results.sarif
+          TRIVY_FORMAT: sarif
+          TRIVY_EXIT_CODE: "0"
+        run: ./scripts/runTrivyImageScan.sh
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-container
+
+      - name: Produce readable report
+        id: table
+        env:
+          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:latest' }}
+          SCAN_OUTPUT: trivy-results.log
+          TRIVY_EXIT_CODE: "0"
+        run: ./scripts/runTrivyImageScan.sh
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-trivy-report
+          path: |
+            trivy-results.log
+            trivy-results.sarif
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Summarise and gate
+        env:
+          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:latest' }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "## Container CVE scan"
+            echo
+            echo "Image: \`${IMAGE_REF}\`"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Trivy prints one "Total: N (...)" line per target. Anything above zero
+          # means a fixable HIGH/CRITICAL is present, since the scan already runs
+          # with --ignore-unfixed.
+          total="$(grep -hoE '^Total: [0-9]+' trivy-results.log 2>/dev/null | awk '{ sum += $2 } END { print sum + 0 }')"
+
+          if [ "$total" -eq 0 ]; then
+            echo "No fixable HIGH or CRITICAL vulnerabilities." >> "$GITHUB_STEP_SUMMARY"
+            echo "Clean."
+            exit 0
+          fi
+
+          {
+            echo "Found **${total}** fixable HIGH/CRITICAL vulnerabilities."
+            echo
+            echo '```'
+            sed -n '/^Total:/,/^$/p' trivy-results.log | head -60
+            echo '```'
+            echo
+            echo "Base image CVEs are normally fixed by the \`Refresh Dockerfile base image digests\` workflow. If that workflow is green and this is still red, the upstream base image has not shipped a patch yet."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::error::${total} fixable HIGH/CRITICAL vulnerabilities in ${IMAGE_REF}"
+          exit 1

--- a/.github/workflows/refresh-dockerfile-digests.yml
+++ b/.github/workflows/refresh-dockerfile-digests.yml
@@ -193,14 +193,29 @@ jobs:
             gh pr edit "$existing_pr_url" \
               --title "chore(docker): ${SUMMARY}" \
               --body-file /tmp/pr-body.md
+            pr_url="$existing_pr_url"
           else
-            gh pr create \
+            # Create the PR WITHOUT labels first. `gh pr create --label` aborts the
+            # whole command when a label does not exist in the repo, and that is not
+            # hypothetical: a missing `docker-dependencies-update` label failed this
+            # step every night for days. The branch kept getting pushed, no PR was
+            # ever opened, and an OpenSSL CVE fix sat unmerged the entire time.
+            # A cosmetic label must never be able to block a security patch.
+            pr_url="$(gh pr create \
               --repo "$REPOSITORY" \
               --base main \
               --head "$BRANCH" \
               --title "chore(docker): ${SUMMARY}" \
-              --body-file /tmp/pr-body.md \
-              --label "dependencies" \
-              --label "docker-dependencies-update" \
-              --label "automated-digest-refresh"
+              --body-file /tmp/pr-body.md)"
           fi
+
+          echo "PR ready: ${pr_url}"
+
+          # Labels are applied best-effort afterwards. Note that the auto-merge job
+          # keys off `automated-digest-refresh`, so a warning here means the PR is
+          # open but needs merging by hand.
+          for label in dependencies docker-dependencies-update automated-digest-refresh; do
+            if ! gh pr edit "$pr_url" --add-label "$label" >/dev/null 2>&1; then
+              echo "::warning::Could not add label '${label}' to ${pr_url}. The PR is open, but auto-merge may not pick it up."
+            fi
+          done

--- a/scripts/runTrivyImageScan.sh
+++ b/scripts/runTrivyImageScan.sh
@@ -5,6 +5,13 @@ IMAGE_REF="${IMAGE_REF:-docker.io/karimz1/imgcompress:latest}"
 SCAN_OUTPUT="${SCAN_OUTPUT:-scan-result.log}"
 TRIVY_IMAGE="${TRIVY_IMAGE:-aquasec/trivy:0.70.0@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e}"
 
+# SCAN_OUTPUT is written inside the container's /work mount, so it must be a path
+# relative to the repository root. Absolute host paths will not resolve.
+# Overridable so the nightly scan can ask for SARIF without duplicating this file.
+TRIVY_FORMAT="${TRIVY_FORMAT:-table}"
+TRIVY_SEVERITY="${TRIVY_SEVERITY:-HIGH,CRITICAL}"
+TRIVY_EXIT_CODE="${TRIVY_EXIT_CODE:-1}"
+
 if ! docker image inspect "$IMAGE_REF" >/dev/null 2>&1; then
   echo "Image '$IMAGE_REF' is not loaded locally. Run the Docker build step first." >&2
   exit 1
@@ -21,10 +28,10 @@ docker run --rm \
   "$TRIVY_IMAGE" \
   image \
   --scanners vuln \
-  --severity HIGH,CRITICAL \
+  --severity "$TRIVY_SEVERITY" \
   --ignore-unfixed \
-  --exit-code 1 \
-  --format table \
+  --exit-code "$TRIVY_EXIT_CODE" \
+  --format "$TRIVY_FORMAT" \
   --output "/work/$SCAN_OUTPUT" \
   "$IMAGE_REF"
 


### PR DESCRIPTION
Follow-up to #813. That PR patches the CVE; this one fixes the automation that should have patched it days ago, and adds the missing detection.

## Why the nightly patching stopped

`refresh-dockerfile-digests` has failed **every run for at least 5 days**, always at the same line:

```
could not add label: 'docker-dependencies-update' not found
##[error]Process completed with exit code 1
```

`gh pr create --label` aborts the whole command when a label does not exist. The label was never created in this repo.

What made it hard to notice is that everything before that point worked. The digest lookup resolved new images, the commit was made, the branch was force-pushed. Only the PR was missing. So `chan/refresh-dockerfile-digests` quietly accumulated the fix while `main` kept shipping a vulnerable OpenSSL.

**Fix:** create the PR first, then apply labels best-effort with a warning if one fails. A cosmetic label must never be able to block a security patch. I also created the missing `docker-dependencies-update` label, so the mechanism works again immediately.

Note the trade-off: if labelling fails, the PR is open but the auto-merge job (which keys off `automated-digest-refresh`) will not pick it up. That is deliberate. An unmerged PR is visible; no PR at all is not.

## Why nothing raised the alarm

The existing Trivy step in `ci-auto-merge.yml`:

- is `continue-on-error: true`, so it never turns anything red
- writes its report to an artifact nobody opens
- only runs on a PR or push, so a CVE disclosed against an **already-published** image never triggers it

That is why a HIGH CVE sat in the shipped image with green pipelines.

**Added** `nightly-container-cve-scan.yml`, which scans the published image daily at 06:00 UTC (after the 04:00 digest refresh, so an overnight fix is reflected):

- uploads SARIF to code scanning, so container CVEs appear in the Security tab next to the CodeQL alerts
- writes a readable summary to the job summary
- fails the run when a fixable HIGH/CRITICAL is present, so a scheduled failure notification actually reaches you

Remediation still belongs to the digest refresh workflow. This is the detector, so a broken or lagging refresh becomes visible instead of silent.

## Script change

`runTrivyImageScan.sh` gains `TRIVY_FORMAT`, `TRIVY_SEVERITY` and `TRIVY_EXIT_CODE` so the nightly job can request SARIF without duplicating the script. **Defaults are unchanged**, so the existing CI step behaves exactly as before.

## Verified locally

Ran against the two real base image digests rather than trusting the wiring:

| Base | SARIF | Table parser |
| --- | --- | --- |
| `sha256:436787c2…` (vulnerable, on `main`) | valid, 1 rule, 3 results | totals `3` |
| `sha256:014bacad…` (patched, in #813) | n/a | totals `0` |

The SARIF step runs with `TRIVY_EXIT_CODE=0` and confirmed exit 0, so the Security tab still gets updated on the run where the gate then fails.

## Merge order

#813 first (patches the CVE), then this one. Either order works, but merging #813 first means the first nightly run of this scan comes back clean.