### PR TITLE
feat(ci): repair Dependabot frontend lockfiles automatically

### DIFF
--- a/.github/workflows/repair-frontend-dependabot-lockfile.yml
+++ b/.github/workflows/repair-frontend-dependabot-lockfile.yml
@@ -1,15 +1,28 @@
 name: Repair frontend Dependabot pnpm lockfile
 
 # Triggered by:
+#   - pull_request_target on Dependabot PRs that touch the frontend manifests
+#     (automatic; no maintainer action needed)
+#   - PR comment "/chan-fix" by karimz1 (manual override / re-run)
 #   - workflow_dispatch (maintainers manually pick a PR number)
-#   - PR comment "/chan-fix" by karimz1
+#
+# The automatic trigger is the point of this workflow. Dependabot regularly opens
+# frontend PRs whose pnpm lockfile is stale, CI goes red, and the security patch
+# then waits on a human to type /chan-fix. With six figures of image pulls that
+# is not a reasonable thing to have a person in the middle of.
+#
+# pull_request_target rather than pull_request: events raised by Dependabot read
+# from the Dependabot secrets store, so the App credentials come back empty on a
+# plain pull_request. handoff-dependabot-ci.yml uses pull_request_target for the
+# same reason.
 #
 # The work is split across two jobs on purpose:
-#   * `regenerate` checks out the PR branch and runs its build tooling, but holds
-#     no secrets and only read permissions.
+#   * `regenerate` holds no secrets and only read permissions. It never checks out
+#     PR code; it pulls the PR's manifests in as data.
 #   * `publish` holds the imgcompress-chan token but never checks out or executes
 #     PR code; it pushes through the GitHub API.
 # Only the regenerated lockfile crosses that boundary, as data rather than code.
+# That separation is what makes an automatic privileged trigger safe here.
 
 on:
   workflow_dispatch:
@@ -20,12 +33,18 @@ on:
         type: number
   issue_comment:
     types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'frontend/package.json'
+      - 'frontend/pnpm-lock.yaml'
+      - 'frontend/pnpm-workspace.yaml'
 
 permissions:
   contents: read
 
 concurrency:
-  group: repair-frontend-lockfile-${{ github.event.issue.number || inputs.pr_number }}
+  group: repair-frontend-lockfile-${{ github.event.issue.number || github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:
@@ -33,6 +52,11 @@ jobs:
     name: regenerate lockfile (unprivileged)
     if: >
       github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.user.login == 'dependabot[bot]' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      ) ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
@@ -53,7 +77,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
-          PR_NUMBER_INPUT: ${{ inputs.pr_number || github.event.issue.number }}
+          PR_NUMBER_INPUT: ${{ inputs.pr_number || github.event.issue.number || github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
@@ -293,8 +317,21 @@ jobs:
           REGEN_RESULT: ${{ needs.regenerate.result }}
           CHANGED: ${{ steps.push.outputs.changed }}
           STATUS: ${{ job.status }}
+          IS_AUTO: ${{ github.event_name == 'pull_request_target' }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          # On the automatic trigger, stay quiet when there was nothing to do.
+          # This fires on every Dependabot frontend PR, and again on the
+          # synchronize raised by our own push, so commenting each time would
+          # bury the PR in noise. A human asking via /chan-fix always gets an
+          # answer, and failures always get one.
+          if [[ "$IS_AUTO" == "true" && "$IS_FORK" != "true" \
+                && "$REGEN_RESULT" == "success" && "$STATUS" == "success" \
+                && "$CHANGED" != "true" ]]; then
+            echo "Automatic run with no lockfile change; skipping the PR comment."
+            exit 0
+          fi
+
           if [[ "$IS_FORK" == "true" ]]; then
             body="### Can't reach this one from here 🥺
 


### PR DESCRIPTION
Builds on #812 (now merged). Single-file change: the workflow's trigger.

## The problem

Dependabot regularly opens frontend PRs with a stale pnpm lockfile. CI goes red, and the patch then sits until someone types `/chan-fix`. That is the only manual step left in an otherwise hands-off chain:

```
dependabot -> handoff -> CI -> auto-merge -> nightly deploy
                  ^
            you, typing /chan-fix
```

At this project's pull volume, a person in that loop is the bottleneck between a published CVE fix and users receiving it.

## The change

A `pull_request_target` trigger for PRs authored by `dependabot[bot]` against this repo, scoped by `paths` to the three frontend manifests so backend and actions PRs do not spin up the job. `/chan-fix` and `workflow_dispatch` are untouched and still work as a manual override or re-run.

`pull_request_target` rather than `pull_request` because Dependabot-raised events read from the Dependabot secrets store, so the App credentials come back empty on a plain `pull_request`. `handoff-dependabot-ci.yml` already uses `pull_request_target` for exactly this reason.

## Why it is safe to fire automatically

Only because of #812. That work made `regenerate` hold no secrets, never check out PR code, and pull the manifests in as data, while `publish` holds the token but executes nothing from the PR. The `dependabot[bot]` author gate and same-repo check come from there too.

Without that separation, this trigger would hand a write-scoped token to attacker-controlled code on every Dependabot PR.

## Loop termination

Our own push raises `synchronize`, the rerun regenerates the same lockfile, the hash comparison reports no change, nothing is pushed. One extra no-op run, then it stops.

## Comment noise

Suppressed on automatic runs that had nothing to do. Otherwise every Dependabot frontend PR would collect a "nothing to repair" note, plus a second one from the synchronize. Verified all six paths against a stubbed `gh`:

| Trigger | Outcome | Comments? |
| --- | --- | --- |
| auto | no change | silent |
| auto | lockfile repaired | yes |
| auto | regenerate failed | yes |
| auto | fork PR | yes |
| `/chan-fix` | no change | yes |
| `/chan-fix` | repaired | yes |

## Worth knowing

This closes the gap using tooling already in the repo. Renovate would cover the same ground natively through its lockfile handling, and is worth evaluating separately as a replacement for both this workflow and `refresh-dockerfile-digests`. That is a larger migration; this lands the fix now.