### PR TITLE
fix(docker): remove unreachable pip and setuptools; scan :nightly across all severities

### DIFF
--- a/.github/workflows/nightly-container-cve-scan.yml
+++ b/.github/workflows/nightly-container-cve-scan.yml
@@ -1,6 +1,16 @@
 name: Nightly container CVE scan
 
-# Scans the PUBLISHED image, which is what users actually run.
+# Scans `:nightly`, the published image built from every push to main.
+#
+# Deliberately not `:latest`. That tag only moves on a release tag, so it lags
+# main by an entire release cycle and would report the same known CVEs every
+# night until the next release, whether or not anything had regressed. Red would
+# stop meaning anything. `:nightly` tracks main, so a failure here means a CVE is
+# present in what main currently produces, which is actionable the same day.
+#
+# The trade-off is explicit: this does not tell you whether `:latest` is clean.
+# It will not be, between a patch landing on main and the next release. Point the
+# `image` input at a release tag if you need to check what release users have.
 #
 # The CI Trivy step only covers images built from a PR or a push, and it is
 # `continue-on-error` with the report tucked into an artifact nobody opens. That
@@ -26,7 +36,7 @@ on:
       image:
         description: "Image reference to scan"
         required: false
-        default: "docker.io/karimz1/imgcompress:latest"
+        default: "docker.io/karimz1/imgcompress:nightly"
 
 permissions:
   contents: read
@@ -50,7 +60,7 @@ jobs:
 
       - name: Pull image under scan
         env:
-          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:latest' }}
+          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:nightly' }}
         run: |
           set -euo pipefail
           echo "Scanning ${IMAGE_REF}"
@@ -60,7 +70,7 @@ jobs:
       # when the run is about to be marked failed by the gate below.
       - name: Produce SARIF report
         env:
-          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:latest' }}
+          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:nightly' }}
           SCAN_OUTPUT: trivy-results.sarif
           TRIVY_FORMAT: sarif
           TRIVY_EXIT_CODE: "0"
@@ -75,7 +85,7 @@ jobs:
       - name: Produce readable report
         id: table
         env:
-          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:latest' }}
+          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:nightly' }}
           SCAN_OUTPUT: trivy-results.log
           TRIVY_EXIT_CODE: "0"
         run: ./scripts/runTrivyImageScan.sh
@@ -93,7 +103,7 @@ jobs:
 
       - name: Summarise and gate
         env:
-          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:latest' }}
+          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:nightly' }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Follow-up to #814. Two changes to container CVE handling.

## 1. Scan target: `:latest` -> `:nightly`

`:latest` is published only on a `refs/tags/release_*` tag; `:nightly` on every push to `main` (`deploy-docker-image.yml`, tag selection lines 73-84).

Scanning `:latest` reports the delta between the last release and current advisories. That set is non-empty for the whole interval between a patch landing on `main` and the next release, independent of any regression, so the job fails on a fixed schedule and the result is not actionable. Scanning `:nightly` bounds the result to the state of `main`.

The `workflow_dispatch` `image` input is unchanged and accepts any tag for on-demand scans of `:latest` or a release.

## 2. Severity gate: `HIGH,CRITICAL` -> `CRITICAL,HIGH,MEDIUM,LOW`

The previous gate is why the two findings below were never reported. `--ignore-unfixed` still applies, so every reported item has a fix available.

## 3. Remove unreachable pip and setuptools

Scanning `:nightly` across all severities leaves two fixable findings, both in the uv-managed standalone Python rather than in `requirements.txt`:

| Severity | CVE | Package | Installed | Fixed in |
| --- | --- | --- | --- | --- |
| MEDIUM | CVE-2026-8643 | pip | 26.1.1 | 26.1.2 |
| MEDIUM | CVE-2026-59890 | setuptools | 82.0.1 | 83.0.0 |

Neither is reachable at runtime. The venv is created without system site-packages, so the standalone interpreter's site-packages is not on `sys.path`:

```
/container/venv/bin/python -c 'import pip'            ModuleNotFoundError
/container/venv/bin/python -c 'import setuptools'     ModuleNotFoundError
/container/venv/bin/python -c 'import pkg_resources'  ModuleNotFoundError
```

They are present only because the interpreter ships with them; the build installs through `uv`, not pip. Removal clears the findings permanently rather than tracking upstream releases for packages the runtime never loads.

`ensurepip` is removed with them. Its bundled wheels are older than the installed copies (pip 24.0, setuptools 79.0.1) and it exists only to bootstrap pip into an interpreter that lacks it.

The step asserts its own outcome. A future base image that reintroduces either package fails the build instead of silently restoring the finding, and a runtime import check guards against removing something that turns out to be required.

## Verification

Local `linux/arm64` build:

| Check | Result |
| --- | --- |
| Trivy, all severities, fixable | 47 on `0.8.3`, 2 on `:nightly`, **0** here |
| Image size | 1.60GB -> 1.59GB |
| Build-time asserts | pip and setuptools unimportable, `flask`+`PIL` import |
| Runtime | 9.1MB JPEG compressed to 677KB, downloaded via `/api/download` |
| Behaviour vs `:nightly` | identical responses on identical requests |
| Path traversal on `/api/download` | still 404 |

## Note

CI builds `linux/amd64`; verification above was on `linux/arm64`. The removal is architecture independent, but the scan gate means a discrepancy would surface as a failed nightly rather than silently.
