### PR TITLE
fix(docker): remove unreachable pip and setuptools from the runtime image

### DIFF
--- a/.github/workflows/nightly-container-cve-scan.yml
+++ b/.github/workflows/nightly-container-cve-scan.yml
@@ -74,6 +74,7 @@ jobs:
           SCAN_OUTPUT: trivy-results.sarif
           TRIVY_FORMAT: sarif
           TRIVY_EXIT_CODE: "0"
+          TRIVY_SEVERITY: "CRITICAL,HIGH,MEDIUM,LOW"
         run: ./scripts/runTrivyImageScan.sh
 
       - name: Upload SARIF to code scanning
@@ -88,6 +89,11 @@ jobs:
           IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:nightly' }}
           SCAN_OUTPUT: trivy-results.log
           TRIVY_EXIT_CODE: "0"
+          # All severities, not just HIGH/CRITICAL. The default gate hid two
+          # fixable MEDIUM findings in the image's pip and setuptools for as long
+          # as they existed. --ignore-unfixed still applies, so anything reported
+          # here has a fix available and is therefore actionable.
+          TRIVY_SEVERITY: "CRITICAL,HIGH,MEDIUM,LOW"
         run: ./scripts/runTrivyImageScan.sh
 
       - name: Upload reports

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,33 @@ COPY --chown=nonroot:nonroot backend/ ./backend
 RUN --mount=type=cache,target=/home/nonroot/.cache/uv,uid=65532,gid=65532 \
     uv pip install .
 
+# Empty the standalone interpreter's own site-packages.
+#
+# uv installs the app into /container/venv, which is created without system
+# site-packages, so the interpreter's site-packages is never on sys.path at
+# runtime. It holds nothing but pip, setuptools and their support files, and the
+# build installs through uv rather than pip, so the whole directory is unused
+# rather than partly unused. It is emptied instead of curated by name.
+#
+# This is not cosmetic. Those two packages were the only vulnerabilities left in
+# the image after the base image patch (CVE-2026-8643 in pip, CVE-2026-59890 in
+# setuptools) and sat below the old HIGH/CRITICAL scan gate unreported. ensurepip
+# goes with them: it bundles older wheels still (pip 24.0, setuptools 79.0.1) and
+# exists only to bootstrap pip into an interpreter that lacks it.
+#
+# The assertions matter more than the deletion. The paths are globbed rather than
+# version-pinned, so a Python upgrade cannot turn this into a silent no-op, and a
+# base image that reintroduces either package fails the build.
+RUN set -eux; \
+    rm -rf /container/python/*/lib/python*/site-packages/* \
+           /container/python/*/lib/python*/ensurepip; \
+    for sp in /container/python/*/lib/python*/site-packages/; do \
+      [ -z "$(ls -A "$sp")" ] || { echo "not empty: $sp" >&2; exit 1; }; \
+    done; \
+    ! /container/venv/bin/python -c 'import pip' 2>/dev/null; \
+    ! /container/venv/bin/python -c 'import setuptools' 2>/dev/null; \
+    /container/venv/bin/python -c 'import flask, PIL; print("runtime imports OK")'
+
 # Pre-download rembg model to prevent download overhead during runtime.
 ENV U2NET_HOME=/container/.u2net
 # Intent: Since backend code is copied earlier, any code change invalidates layer cache.


### PR DESCRIPTION
Carries the second commit of #816, which was merged before this commit was pushed. Main currently has the `:nightly` scan-target change but not the fix below, so `:nightly` still reports 2 findings.

## Findings addressed

Scanning `:nightly` across all severities leaves two fixable items, both in the uv-managed standalone Python rather than in `requirements.txt`, which is why neither Dependabot nor the previous `HIGH,CRITICAL` gate reported them:

| Severity | CVE | Package | Installed | Fixed in |
| --- | --- | --- | --- | --- |
| MEDIUM | CVE-2026-8643 | pip | 26.1.1 | 26.1.2 |
| MEDIUM | CVE-2026-59890 | setuptools | 82.0.1 | 83.0.0 |

## Approach

Neither package is reachable at runtime. The venv is created without system site-packages, so the standalone interpreter's site-packages is not on `sys.path`:

```
/container/venv/bin/python -c 'import pip'            ModuleNotFoundError
/container/venv/bin/python -c 'import setuptools'     ModuleNotFoundError
/container/venv/bin/python -c 'import pkg_resources'  ModuleNotFoundError
```

They are present only because the interpreter ships with them; the build installs through `uv`, not pip. Removal clears the findings permanently rather than tracking upstream releases for packages the runtime never loads.

`ensurepip` is removed with them: its bundled wheels are older than the installed copies (pip 24.0, setuptools 79.0.1) and it exists only to bootstrap pip into an interpreter that lacks it.

The step asserts its own outcome, so a base image that reintroduces either package fails the build instead of silently restoring the finding. A runtime import check guards against removing something that turns out to be required.

## Severity gate

The nightly scan now requests `CRITICAL,HIGH,MEDIUM,LOW`. The previous `HIGH,CRITICAL` gate is why both findings went unreported. `--ignore-unfixed` still applies, so everything reported has a fix available.

## Verification

Local `linux/arm64` build:

| Check | Result |
| --- | --- |
| Trivy, all severities, fixable | 47 on `0.8.3`, 2 on `:nightly`, **0** here |
| Image size | 1.60GB -> 1.59GB |
| Build-time asserts | pip and setuptools unimportable, `flask`+`PIL` import |
| Runtime | 9.1MB JPEG compressed to 677KB, downloaded via `/api/download` |
| Behaviour vs `:nightly` | identical responses on identical requests |
| Path traversal on `/api/download` | still 404 |

CI builds `linux/amd64`; the verification above was on `linux/arm64`. The removal is architecture independent, and the new gate means any discrepancy surfaces as a failed nightly rather than silently.
