### PR TITLE
fix(docker): move the image to Python 3.14 and drop dead dependencies

### DIFF
--- a/.devcontainer/requirements-dev.txt
+++ b/.devcontainer/requirements-dev.txt
@@ -1,12 +1,9 @@
-cffi==2.0.0
 coverage==7.15.3
 exceptiongroup==1.3.1
 iniconfig==2.3.0
 packaging==26.3
 pillow==12.3.0
 pluggy==1.6.0
-pycparser==3.0
-pyheif==0.8.0
 pytest==9.1.1
 pytest-cov==7.1.0
 ruff==0.16.1

--- a/.github/workflows/nightly-container-cve-scan.yml
+++ b/.github/workflows/nightly-container-cve-scan.yml
@@ -74,6 +74,7 @@ jobs:
           SCAN_OUTPUT: trivy-results.sarif
           TRIVY_FORMAT: sarif
           TRIVY_EXIT_CODE: "0"
+          TRIVY_SEVERITY: "CRITICAL,HIGH,MEDIUM,LOW"
         run: ./scripts/runTrivyImageScan.sh
 
       - name: Upload SARIF to code scanning
@@ -88,6 +89,11 @@ jobs:
           IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:nightly' }}
           SCAN_OUTPUT: trivy-results.log
           TRIVY_EXIT_CODE: "0"
+          # All severities, not just HIGH/CRITICAL. The default gate hid two
+          # fixable MEDIUM findings in the image's pip and setuptools for as long
+          # as they existed. --ignore-unfixed still applies, so anything reported
+          # here has a fix available and is therefore actionable.
+          TRIVY_SEVERITY: "CRITICAL,HIGH,MEDIUM,LOW"
         run: ./scripts/runTrivyImageScan.sh
 
       - name: Upload reports

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN pnpm run build
 
 # The built static files are in /app/frontend/out/
 
-
 # Stage 2: PYTHON BACKEND BUILD
 # ------------------------------------------------------------------------------------------
 # Intent: Fallback to debian-base:trixie-debian13-dev because dhi.io/python:3.11-debian13 is 
@@ -36,7 +35,7 @@ FROM dhi.io/debian-base:trixie-debian13-dev@sha256:4440cf16b142316744a7fd1c5070e
 
 # Use 'uv' for high-performance Python package management instead of standard pip.
 # Ref: https://github.com/astral-sh/uv
-COPY --from=dhi.io/uv:0.11.18-debian13@sha256:be1c2d5905075a57885f83a04f4f64eab0d4b99c4695803d9a707a7fd448152d /uv /uvx /bin/
+COPY --from=dhi.io/uv:0.11.31-debian13@sha256:a39297c8ffc840971da90952aec9123d991bd007a0402edb2fd814421506d622 /uv /uvx /bin/
 
 # 🧩 Install system dependencies required for full Pillow image format support
 #
@@ -115,10 +114,21 @@ ENV VIRTUAL_ENV=/container/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # Setup standalone Python managed by uv to avoid missing python in final stage.
 # This standalone python is statically built and does not depend on OS libraries.
+#
+# Pinned to 3.14 rather than 3.11. Beyond being current, the standalone builds
+# from 3.12 onwards no longer bundle setuptools and ship a patched pip, which is
+# what removes the last vulnerabilities from the image:
+#
+#   3.11  pip 26.1.1 (CVE-2026-8643)  setuptools 82.0.1 (CVE-2026-59890)
+#   3.14  pip 26.1.2                  setuptools not shipped
+#
+# Neither package is reachable at runtime in any case, since the venv is created
+# without system site-packages, but the scanner reports what is present on disk.
 ENV UV_PYTHON_INSTALL_DIR=/container/python
+ENV PYTHON_VERSION=3.14
 RUN --mount=type=cache,target=/home/nonroot/.cache/uv,uid=65532,gid=65532 \
-    uv python install 3.11 && \
-    uv venv --python 3.11 $VIRTUAL_ENV
+    uv python install "$PYTHON_VERSION" && \
+    uv venv --python "$PYTHON_VERSION" $VIRTUAL_ENV
 
 WORKDIR /container
 
@@ -153,7 +163,6 @@ COPY --chown=nonroot:nonroot healthcheck.py ./healthcheck.py
 # Create static site directory. Required pre-creation as a nonroot user 
 # to avoid permission issues when copying frontend assets.
 RUN mkdir -p /container/backend/image_converter/presentation/web/static_site
-
 
 # Stage 3: FINAL RUNTIME
 # ------------------------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
 werkzeug
-cffi==2.0.0
 pillow>=12.3.0
-pycparser==3.0
-pyheif==0.8.0
 colorama==0.4.6
 flask==3.1.3
 apscheduler==3.11.3

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(
     packages=find_packages(),
     install_requires=[
         'Pillow>=9.0.0',
-        'pyheif>=0.6.0',
         'pypdfium2>=4.30.0',
     ],
     entry_points={


### PR DESCRIPTION
Replaces #817, which resolved the same findings by deleting files from the interpreter at build time. Nothing is deleted here.

## Findings

| Severity | CVE | Package | On `:nightly` | Resolution |
| --- | --- | --- | --- | --- |
| MEDIUM | CVE-2026-59890 | setuptools | 82.0.1 | not shipped from Python 3.12 onwards |
| MEDIUM | CVE-2026-8643 | pip | 26.1.1 | 26.1.2 via uv 0.11.31 |

Both live in the uv-managed standalone interpreter rather than in `requirements.txt`, which is why neither Dependabot nor the previous `HIGH,CRITICAL` gate reported them.

## Python 3.11 -> 3.14

Standalone builds stopped bundling setuptools at 3.12, so CVE-2026-59890 disappears by construction.

## uv 0.11.18 -> 0.11.31

Required, not incidental. The pinned older uv resolves to a python-build-standalone release carrying pip 26.1.1, so the Python bump alone still left CVE-2026-8643 in the image (measured: 3.14 built with uv 0.11.18 ships pip 26.1.1). uv 0.11.31 pulls a release with pip 26.1.2.

## Dead dependencies

`pyheif` has no code references anywhere in the repository. HEIF support comes from `pillow_heif`, which is imported and registers the Pillow opener. Its wheels also stop at cp312, so without a cp314 wheel the build fell back to compiling from source and failed on the absent compiler: an unused dependency was capping the interpreter version.

`cffi` existed for `pyheif`. Verified against the built image, it is now required by nothing, and `pycparser` is required only by `cffi`.

Removed from `requirements.txt`, `setup.py` and `.devcontainer/requirements-dev.txt`.

## Severity gate

The nightly scan requests `CRITICAL,HIGH,MEDIUM,LOW`. The previous `HIGH,CRITICAL` gate is why both findings went unreported. `--ignore-unfixed` still applies, so everything reported has a fix available.

## Verification

Local `linux/arm64` build:

| Check | Result |
| --- | --- |
| Trivy, all severities, fixable | **0** (2 on `:nightly`, 47 on `0.8.3`) |
| Interpreter | Python 3.14.6, pip 26.1.2, setuptools not shipped |
| Image size | 1.60GB -> 1.58GB |
| Conversions | heic, psd, jpg, eps, pdf all return `status: ok` |
| Background removal | rembg + onnxruntime `status: ok` |
| Native imports | onnxruntime, rembg, pypdfium2, psd_tools, pillow_heif, fpdf, granian, PIL, flask, apscheduler |

HEIC was exercised specifically, since `pyheif` was removed.
