### PR TITLE
Add Trivy convert mode and report renderer

### DIFF
--- a/.github/workflows/ci-auto-merge.yml
+++ b/.github/workflows/ci-auto-merge.yml
@@ -60,7 +60,7 @@ jobs:
           python -m pip install ruff==0.15.14
 
       - name: Run Ruff
-        run: ruff check backend tests healthcheck.py update_dockerhub_description.py
+        run: ruff check backend tests healthcheck.py update_dockerhub_description.py scripts/trivy_report_summary.py
 
   scan-image:
     name: scan local image

--- a/.github/workflows/nightly-container-cve-scan.yml
+++ b/.github/workflows/nightly-container-cve-scan.yml
@@ -19,7 +19,21 @@ name: Nightly container CVE scan
 #   1. A CVE disclosed against an already-published image surfaces without any
 #      code change, so nothing in CI would ever run and notice it.
 #   2. Findings were invisible. Results now upload as SARIF and appear in the
-#      Security tab next to the CodeQL alerts.
+#      Security tab next to the CodeQL alerts, are rendered as a table in the run
+#      summary, and are tracked in an issue for as long as they are unfixed.
+#
+# One scan, three reports: Trivy runs once and writes JSON, and `trivy convert`
+# renders the SARIF and table views from that same result set. Every number the
+# gate and the reports use is read from the JSON, never scraped out of the
+# human-readable table. The previous gate grepped that table for `Total: N`,
+# which Trivy only prints for targets that have findings, so a clean image
+# produced no match, `grep` exited 1 under `pipefail`, and the run failed while
+# the image was green.
+#
+# Gate: only a fixable CRITICAL fails the run. HIGH, MEDIUM and LOW are still
+# scanned and reported everywhere, but they do not turn the nightly red on their
+# own; the scan already runs with --ignore-unfixed, so everything reported has a
+# fix available.
 #
 # Remediation itself stays with `refresh-dockerfile-digests.yml`: base image CVEs
 # are fixed by DHI rebuilding the image, which moves the digest and opens a PR.
@@ -45,6 +59,13 @@ concurrency:
   group: nightly-container-cve-scan
   cancel-in-progress: false
 
+env:
+  IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:nightly' }}
+  GATE_SEVERITY: CRITICAL
+  # Comma separated; each is applied only if it already exists in the repo.
+  ISSUE_LABELS: "Security,CVEs"
+  MAINTAINER: karimz1
+
 jobs:
   scan:
     name: Scan published image
@@ -52,49 +73,90 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      # Fallback only: the tracking issue is normally written by the
+      # imgcompress-chan App token minted below.
+      issues: write
     steps:
+      - name: Mint imgcompress-chan token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.IMGCOMPRESS_CHAN_APP_ID }}
+          private-key: ${{ secrets.IMGCOMPRESS_CHAN_PRIVATE_KEY }}
+          permission-issues: write
+
       - name: Check out repository
         uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Pull image under scan
-        env:
-          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:nightly' }}
+        id: pull
         run: |
           set -euo pipefail
           echo "Scanning ${IMAGE_REF}"
           docker pull "$IMAGE_REF"
 
-      # SARIF first, and never fail on it, so the Security tab is updated even
-      # when the run is about to be marked failed by the gate below.
-      - name: Produce SARIF report
-        env:
-          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:nightly' }}
-          SCAN_OUTPUT: trivy-results.sarif
-          TRIVY_FORMAT: sarif
-          TRIVY_EXIT_CODE: "0"
-          TRIVY_SEVERITY: "CRITICAL,HIGH,MEDIUM,LOW"
-        run: ./scripts/runTrivyImageScan.sh
+          digest="$(docker image inspect "$IMAGE_REF" --format '{{ if .RepoDigests }}{{ index .RepoDigests 0 }}{{ end }}')"
+          echo "digest=${digest##*@}" >> "$GITHUB_OUTPUT"
 
-      - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-results.sarif
-          category: trivy-container
-
-      - name: Produce readable report
-        id: table
+      # JSON is the source of truth. Never fails on findings: the gate at the end
+      # of the job owns that decision, so the reports below are always produced.
+      - name: Produce JSON report
         env:
-          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:nightly' }}
-          SCAN_OUTPUT: trivy-results.log
+          SCAN_OUTPUT: trivy-results.json
+          TRIVY_FORMAT: json
           TRIVY_EXIT_CODE: "0"
-          # All severities, not just HIGH/CRITICAL. The default gate hid two
+          # All severities, not just HIGH/CRITICAL. The default filter hid two
           # fixable MEDIUM findings in the image's pip and setuptools for as long
           # as they existed. --ignore-unfixed still applies, so anything reported
           # here has a fix available and is therefore actionable.
           TRIVY_SEVERITY: "CRITICAL,HIGH,MEDIUM,LOW"
         run: ./scripts/runTrivyImageScan.sh
+
+      - name: Convert report to SARIF
+        env:
+          SCAN_OUTPUT: trivy-results.sarif
+          TRIVY_CONVERT_FROM: trivy-results.json
+          TRIVY_FORMAT: sarif
+          TRIVY_EXIT_CODE: "0"
+        run: ./scripts/runTrivyImageScan.sh
+
+      - name: Convert report to table
+        env:
+          SCAN_OUTPUT: trivy-results.log
+          TRIVY_CONVERT_FROM: trivy-results.json
+          TRIVY_FORMAT: table
+          TRIVY_EXIT_CODE: "0"
+        run: ./scripts/runTrivyImageScan.sh
+
+      - name: Upload SARIF to code scanning
+        if: always() && hashFiles('trivy-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-container
+
+      - name: Render report
+        id: report
+        env:
+          DIGEST: ${{ steps.pull.outputs.digest }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          trivy_version="$(jq -r '.runs[0].tool.driver.version // ""' trivy-results.sarif)"
+
+          python3 scripts/trivy_report_summary.py trivy-results.json \
+            --image "$IMAGE_REF" \
+            --digest "$DIGEST" \
+            --trivy-version "$trivy_version" \
+            --run-url "$RUN_URL" \
+            --gate-severity "$GATE_SEVERITY" \
+            --summary-out "$GITHUB_STEP_SUMMARY" \
+            --issue-out issue-body.md \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Upload reports
         if: always()
@@ -102,44 +164,116 @@ jobs:
         with:
           name: nightly-trivy-report
           path: |
+            trivy-results.json
             trivy-results.log
             trivy-results.sarif
+            issue-body.md
           retention-days: 14
           if-no-files-found: warn
 
-      - name: Summarise and gate
+      # A scheduled run that goes red is easy to miss, so findings are also
+      # tracked in a single issue: opened when a fixable CRITICAL appears,
+      # updated silently while the finding set is unchanged, commented on when it
+      # changes, and closed automatically once the image is clean again.
+      - name: Sync tracking issue
+        if: always() && steps.report.outcome == 'success'
         env:
-          IMAGE_REF: ${{ inputs.image || 'docker.io/karimz1/imgcompress:nightly' }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CRITICAL: ${{ steps.report.outputs.critical }}
+          TOTAL: ${{ steps.report.outputs.total }}
+          FINGERPRINT: ${{ steps.report.outputs.fingerprint }}
         run: |
           set -euo pipefail
 
-          {
-            echo "## Container CVE scan"
-            echo
-            echo "Image: \`${IMAGE_REF}\`"
-            echo
-          } >> "$GITHUB_STEP_SUMMARY"
+          marker="<!-- nightly-cve-scan:${IMAGE_REF} -->"
+          title="Container CVEs in ${IMAGE_REF}"
 
-          # Trivy prints one "Total: N (...)" line per target. Anything above zero
-          # means a fixable HIGH/CRITICAL is present, since the scan already runs
-          # with --ignore-unfixed.
-          total="$(grep -hoE '^Total: [0-9]+' trivy-results.log 2>/dev/null | awk '{ sum += $2 } END { print sum + 0 }')"
+          # Narrow by title first so a busy issue tracker cannot push the
+          # tracking issue past the page limit, then confirm on the hidden
+          # marker so renaming the issue never orphans it.
+          existing="$(gh issue list --repo "$REPOSITORY" --state open --limit 100 --search "in:title Container CVEs" --json number,body |
+            jq -r --arg marker "$marker" 'map(select((.body // "") | contains($marker))) | (.[0].number // "")')"
+          previous_body=""
+          if [ -n "$existing" ]; then
+            previous_body="$(gh issue view "$existing" --repo "$REPOSITORY" --json body --jq '.body // ""')"
+          fi
 
-          if [ "$total" -eq 0 ]; then
-            echo "No fixable HIGH or CRITICAL vulnerabilities." >> "$GITHUB_STEP_SUMMARY"
-            echo "Clean."
+          if [ "$CRITICAL" -eq 0 ]; then
+            if [ -z "$existing" ]; then
+              echo "Image is clean and no tracking issue is open. Nothing to do."
+              exit 0
+            fi
+
+            gh issue comment "$existing" --repo "$REPOSITORY" --body "$(cat <<EOF
+          @${MAINTAINER} the previously reported ${GATE_SEVERITY} vulnerabilities are no longer present in \`${IMAGE_REF}\`. Closing this issue automatically.
+
+          Run: ${RUN_URL}
+          EOF
+          )"
+            gh issue close "$existing" --repo "$REPOSITORY" --reason completed
+            echo "Closed tracking issue #${existing}."
             exit 0
           fi
 
-          {
-            echo "Found **${total}** fixable HIGH/CRITICAL vulnerabilities."
-            echo
-            echo '```'
-            sed -n '/^Total:/,/^$/p' trivy-results.log | head -60
-            echo '```'
-            echo
-            echo "Base image CVEs are normally fixed by the \`Refresh Dockerfile base image digests\` workflow. If that workflow is green and this is still red, the upstream base image has not shipped a patch yet."
-          } >> "$GITHUB_STEP_SUMMARY"
+          # Labels are applied only when they already exist, so the workflow
+          # never needs permission to create them and a renamed label degrades
+          # to an unlabelled issue instead of a failed step.
+          existing_labels="$(gh label list --repo "$REPOSITORY" --limit 200 --json name --jq '.[].name')"
+          label_args=()
+          while IFS= read -r label; do
+            [ -n "$label" ] || continue
+            if printf '%s\n' "$existing_labels" | grep -qxF "$label"; then
+              label_args+=(--label "$label")
+            else
+              echo "Label '${label}' does not exist in ${REPOSITORY}; skipping it."
+            fi
+          done <<< "${ISSUE_LABELS//,/$'\n'}"
 
-          echo "::error::${total} fixable HIGH/CRITICAL vulnerabilities in ${IMAGE_REF}"
-          exit 1
+          if [ -z "$existing" ]; then
+            issue_url="$(gh issue create --repo "$REPOSITORY" --title "$title" --body-file issue-body.md "${label_args[@]}")"
+            existing="${issue_url##*/}"
+            echo "Opened tracking issue #${existing}."
+            notify=true
+          else
+            previous_fingerprint="$(printf '%s\n' "$previous_body" | sed -n 's/^<!-- fingerprint:\(.*\) -->$/\1/p' | head -n 1)"
+            gh issue edit "$existing" --repo "$REPOSITORY" --body-file issue-body.md
+            if [ "$previous_fingerprint" = "$FINGERPRINT" ]; then
+              echo "Tracking issue #${existing} refreshed; finding set unchanged, no comment posted."
+              notify=false
+            else
+              echo "Tracking issue #${existing} refreshed; finding set changed."
+              notify=true
+            fi
+          fi
+
+          if [ "$notify" = true ]; then
+            gh issue comment "$existing" --repo "$REPOSITORY" --body "$(cat <<EOF
+          @${MAINTAINER} \`${IMAGE_REF}\` currently ships ${CRITICAL} fixable ${GATE_SEVERITY} vulnerability(ies), out of ${TOTAL} fixable finding(s) in total. The full breakdown is in the issue description above.
+
+          Base image CVEs are normally cleared by the \`Refresh Dockerfile base image digests\` workflow. If that workflow is green and this is still red, upstream has not shipped a patch yet.
+
+          Run: ${RUN_URL}
+          EOF
+          )"
+          fi
+
+      - name: Gate
+        env:
+          CRITICAL: ${{ steps.report.outputs.critical }}
+          TOTAL: ${{ steps.report.outputs.total }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${CRITICAL:-}" ]; then
+            echo "::error::The report step produced no counts; the scan did not complete."
+            exit 1
+          fi
+
+          if [ "$CRITICAL" -gt 0 ]; then
+            echo "::error::${CRITICAL} fixable ${GATE_SEVERITY} vulnerabilities in ${IMAGE_REF}"
+            exit 1
+          fi
+
+          echo "No fixable ${GATE_SEVERITY} vulnerabilities in ${IMAGE_REF} (${TOTAL} lower-severity finding(s))."

--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,9 @@ docs/assets/vendor/
 
 # local worktrees
 **/worktrees/
+# Trivy scan output
+scan-result.log
+trivy-results.json
+trivy-results.log
+trivy-results.sarif
+issue-body.md

--- a/scripts/runPythonLint.sh
+++ b/scripts/runPythonLint.sh
@@ -6,9 +6,9 @@ if [ -f /venv/bin/activate ]; then
 fi
 
 if command -v ruff >/dev/null 2>&1; then
-  ruff check backend tests healthcheck.py update_dockerhub_description.py
+  ruff check backend tests healthcheck.py update_dockerhub_description.py scripts/trivy_report_summary.py
 elif command -v uvx >/dev/null 2>&1; then
-  uvx ruff check backend tests healthcheck.py update_dockerhub_description.py
+  uvx ruff check backend tests healthcheck.py update_dockerhub_description.py scripts/trivy_report_summary.py
 else
   echo "ruff is required. Install ruff or run through the devcontainer." >&2
   exit 127

--- a/scripts/runTrivyImageScan.sh
+++ b/scripts/runTrivyImageScan.sh
@@ -12,7 +12,19 @@ TRIVY_FORMAT="${TRIVY_FORMAT:-table}"
 TRIVY_SEVERITY="${TRIVY_SEVERITY:-HIGH,CRITICAL}"
 TRIVY_EXIT_CODE="${TRIVY_EXIT_CODE:-1}"
 
-if ! docker image inspect "$IMAGE_REF" >/dev/null 2>&1; then
+# When set to a Trivy JSON report (repo-relative, like SCAN_OUTPUT), re-render
+# that report into TRIVY_FORMAT instead of scanning again. Lets a caller scan
+# once and emit JSON, SARIF and table from one identical result set, rather than
+# running three scans that could disagree if the vulnerability DB moves between
+# them. No local image is required in this mode.
+TRIVY_CONVERT_FROM="${TRIVY_CONVERT_FROM:-}"
+
+if [ -n "$TRIVY_CONVERT_FROM" ]; then
+  if [ ! -f "$TRIVY_CONVERT_FROM" ]; then
+    echo "Report '$TRIVY_CONVERT_FROM' does not exist. Run the JSON scan first." >&2
+    exit 1
+  fi
+elif ! docker image inspect "$IMAGE_REF" >/dev/null 2>&1; then
   echo "Image '$IMAGE_REF' is not loaded locally. Run the Docker build step first." >&2
   exit 1
 fi
@@ -20,19 +32,37 @@ fi
 mkdir -p "$(dirname "$SCAN_OUTPUT")"
 mkdir -p .trivy-cache
 
+if [ -n "$TRIVY_CONVERT_FROM" ]; then
+  trivy_args=(
+    convert
+    --format "$TRIVY_FORMAT"
+    --exit-code "$TRIVY_EXIT_CODE"
+    --output "/work/$SCAN_OUTPUT"
+    "/work/$TRIVY_CONVERT_FROM"
+  )
+else
+  trivy_args=(
+    image
+    --scanners vuln
+    --severity "$TRIVY_SEVERITY"
+    --ignore-unfixed
+    --exit-code "$TRIVY_EXIT_CODE"
+    --format "$TRIVY_FORMAT"
+    --output "/work/$SCAN_OUTPUT"
+    "$IMAGE_REF"
+  )
+fi
+
 docker run --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$PWD:/work" \
   -v "$PWD/.trivy-cache:/root/.cache/trivy" \
   -w /work \
   "$TRIVY_IMAGE" \
-  image \
-  --scanners vuln \
-  --severity "$TRIVY_SEVERITY" \
-  --ignore-unfixed \
-  --exit-code "$TRIVY_EXIT_CODE" \
-  --format "$TRIVY_FORMAT" \
-  --output "/work/$SCAN_OUTPUT" \
-  "$IMAGE_REF"
+  "${trivy_args[@]}"
 
-echo "Trivy scan written to $SCAN_OUTPUT"
+if [ -n "$TRIVY_CONVERT_FROM" ]; then
+  echo "Trivy report converted from $TRIVY_CONVERT_FROM to $SCAN_OUTPUT ($TRIVY_FORMAT)"
+else
+  echo "Trivy scan written to $SCAN_OUTPUT"
+fi

--- a/scripts/trivy_report_summary.py
+++ b/scripts/trivy_report_summary.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Render a Trivy JSON report into the artefacts the nightly CVE scan publishes.
+
+The nightly workflow used to decide whether the image was clean by grepping the
+human-readable table report for "Total: N". Trivy only prints that line for
+targets that actually have findings, so a clean image produced no match, grep
+exited 1, and `set -o pipefail` failed the step: green images turned the run
+red. Every number here comes from the JSON report instead, which is stable
+across Trivy releases and cannot fail open.
+
+The scan runs with --ignore-unfixed, so everything reported here has a fix
+available upstream and is therefore actionable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import NamedTuple, Sequence
+
+SEVERITIES = ("CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN")
+
+# Long reports are unreadable in a job summary and GitHub truncates the page at
+# 1 MiB anyway. The omitted count is always printed, never silently dropped.
+MAX_TABLE_ROWS = 50
+
+REMEDIATION_NOTE = (
+    "Base image CVEs are normally cleared by the `Refresh Dockerfile base image "
+    "digests` workflow, which reopens a PR whenever the upstream digest moves. "
+    "If that workflow is green and this is still red, upstream has not shipped a "
+    "patch yet."
+)
+
+
+class Finding(NamedTuple):
+    severity: str
+    vuln_id: str
+    package: str
+    installed: str
+    fixed: str
+    pkg_type: str
+    target: str
+    url: str
+
+    @property
+    def key(self) -> tuple[str, str, str, str]:
+        """Identity used for de-duplication and for the fingerprint."""
+        return (self.target, self.package, self.vuln_id, self.installed)
+
+
+def _severity_rank(severity: str) -> int:
+    try:
+        return SEVERITIES.index(severity)
+    except ValueError:
+        return len(SEVERITIES)
+
+
+def load_findings(report: dict) -> list[Finding]:
+    """Flatten a Trivy JSON report into de-duplicated, severity-sorted findings.
+
+    Trivy repeats the same CVE once per affected target, and a package can be
+    vendored into several targets inside one image, so identical rows are
+    collapsed on (target, package, id, installed version).
+    """
+    seen: dict[tuple[str, str, str, str], Finding] = {}
+
+    for result in report.get("Results") or []:
+        target = str(result.get("Target") or "")
+        pkg_type = str(result.get("Type") or "")
+        for vuln in result.get("Vulnerabilities") or []:
+            finding = Finding(
+                severity=str(vuln.get("Severity") or "UNKNOWN").upper(),
+                vuln_id=str(vuln.get("VulnerabilityID") or "UNKNOWN"),
+                package=str(vuln.get("PkgName") or ""),
+                installed=str(vuln.get("InstalledVersion") or ""),
+                fixed=str(vuln.get("FixedVersion") or ""),
+                pkg_type=pkg_type,
+                target=target,
+                url=str(vuln.get("PrimaryURL") or ""),
+            )
+            seen.setdefault(finding.key, finding)
+
+    return sorted(
+        seen.values(),
+        key=lambda f: (_severity_rank(f.severity), f.vuln_id, f.package, f.target),
+    )
+
+
+def count_by_severity(findings: Sequence[Finding]) -> dict[str, int]:
+    counts = {severity: 0 for severity in SEVERITIES}
+    for finding in findings:
+        counts[finding.severity] = counts.get(finding.severity, 0) + 1
+    return counts
+
+
+def fingerprint(findings: Sequence[Finding]) -> str:
+    """Stable digest of the finding set, independent of report ordering.
+
+    The tracking issue stores this so a nightly run that finds exactly what the
+    previous one found updates the issue silently instead of commenting again.
+    """
+    joined = "\n".join(sorted("|".join(f.key) for f in findings))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16]
+
+
+def _cve_cell(finding: Finding) -> str:
+    if finding.url:
+        return f"[{finding.vuln_id}]({finding.url})"
+    return finding.vuln_id
+
+
+def render_table(findings: Sequence[Finding], max_rows: int = MAX_TABLE_ROWS) -> list[str]:
+    lines = [
+        "| Severity | CVE | Package | Installed | Fixed in | Type |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for finding in findings[:max_rows]:
+        lines.append(
+            "| {severity} | {cve} | `{package}` | `{installed}` | `{fixed}` | {pkg_type} |".format(
+                severity=finding.severity,
+                cve=_cve_cell(finding),
+                package=finding.package,
+                installed=finding.installed or "-",
+                fixed=finding.fixed or "-",
+                pkg_type=finding.pkg_type or "-",
+            )
+        )
+
+    omitted = len(findings) - max_rows
+    if omitted > 0:
+        lines.append("")
+        lines.append(
+            f"{omitted} further finding(s) omitted from this table. "
+            "The full list is in the `trivy-results.log` artifact and in the Security tab."
+        )
+    return lines
+
+
+def render_counts(counts: dict[str, int]) -> list[str]:
+    present = [s for s in SEVERITIES if counts.get(s)]
+    if not present:
+        return []
+    header = "| " + " | ".join(present) + " |"
+    divider = "| " + " | ".join("---" for _ in present) + " |"
+    values = "| " + " | ".join(str(counts[s]) for s in present) + " |"
+    return [header, divider, values]
+
+
+def _metadata_lines(
+    image: str,
+    digest: str,
+    trivy_version: str,
+    run_url: str,
+) -> list[str]:
+    lines = [f"**Image:** `{image}`"]
+    if digest:
+        lines.append(f"**Digest:** `{digest}`")
+    if trivy_version:
+        lines.append(f"**Scanner:** Trivy {trivy_version}")
+    if run_url:
+        lines.append(f"**Run:** {run_url}")
+    return [line + "  " for line in lines]
+
+
+def render_summary(
+    findings: Sequence[Finding],
+    *,
+    image: str,
+    digest: str = "",
+    trivy_version: str = "",
+    run_url: str = "",
+    gate_severity: str = "CRITICAL",
+) -> str:
+    counts = count_by_severity(findings)
+    blocking = counts.get(gate_severity, 0)
+
+    lines = ["## Container CVE scan", ""]
+    lines += _metadata_lines(image, digest, trivy_version, run_url)
+    lines.append("")
+
+    if not findings:
+        lines.append(
+            "**Result:** clean. No fixable vulnerabilities of any severity were found."
+        )
+        return "\n".join(lines) + "\n"
+
+    if blocking:
+        lines.append(
+            f"**Result:** failed. {blocking} fixable {gate_severity} "
+            f"vulnerability(ies) present in the published image."
+        )
+    else:
+        lines.append(
+            f"**Result:** passed. No fixable {gate_severity} vulnerabilities; "
+            f"{len(findings)} lower-severity finding(s) listed below for awareness."
+        )
+
+    lines.append("")
+    lines += render_counts(counts)
+    lines.append("")
+    lines += render_table(findings)
+    lines.append("")
+    lines.append(REMEDIATION_NOTE)
+    lines.append("")
+    lines.append(
+        "Every finding below has a fix available upstream; the scan runs with "
+        "`--ignore-unfixed`."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def render_issue_body(
+    findings: Sequence[Finding],
+    *,
+    image: str,
+    marker: str,
+    digest: str = "",
+    trivy_version: str = "",
+    run_url: str = "",
+    gate_severity: str = "CRITICAL",
+) -> str:
+    counts = count_by_severity(findings)
+    blocking = counts.get(gate_severity, 0)
+
+    lines = [
+        marker,
+        f"<!-- fingerprint:{fingerprint(findings)} -->",
+        "",
+        f"The nightly container scan found **{blocking} fixable {gate_severity}** "
+        f"vulnerability(ies) in `{image}`.",
+        "",
+    ]
+    lines += _metadata_lines(image, digest, trivy_version, run_url)
+    lines.append("")
+    lines += render_counts(counts)
+    lines.append("")
+    lines += render_table(findings)
+    lines.append("")
+    lines.append(REMEDIATION_NOTE)
+    lines.append("")
+    lines.append(
+        "This issue is maintained automatically by the `Nightly container CVE scan` "
+        "workflow and is closed once the image is clean."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def render_outputs(findings: Sequence[Finding]) -> str:
+    counts = count_by_severity(findings)
+    pairs = {severity.lower(): counts.get(severity, 0) for severity in SEVERITIES}
+    pairs["total"] = len(findings)
+    pairs["fingerprint"] = fingerprint(findings)
+    return "".join(f"{key}={value}\n" for key, value in pairs.items())
+
+
+def _write(path: str | None, content: str, mode: str = "w") -> None:
+    """Write content to path; "-" means stdout.
+
+    $GITHUB_STEP_SUMMARY and $GITHUB_OUTPUT are append-only command files that
+    other steps also write to, so those two are opened in append mode.
+    """
+    if not path:
+        return
+    if path == "-":
+        sys.stdout.write(content)
+        return
+    target = Path(path)
+    if str(target.parent) not in (".", ""):
+        target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open(mode, encoding="utf-8") as handle:
+        handle.write(content)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render a Trivy JSON report into markdown reports and workflow outputs."
+    )
+    parser.add_argument("report", help="Path to a Trivy JSON report")
+    parser.add_argument("--image", required=True, help="Image reference that was scanned")
+    parser.add_argument("--digest", default="", help="Repo digest of the scanned image")
+    parser.add_argument("--trivy-version", default="", help="Trivy version used")
+    parser.add_argument("--run-url", default="", help="URL of the workflow run")
+    parser.add_argument(
+        "--gate-severity",
+        default="CRITICAL",
+        choices=list(SEVERITIES),
+        help="Severity that fails the run (default: CRITICAL)",
+    )
+    parser.add_argument("--marker", default="", help="Hidden marker identifying the tracking issue")
+    parser.add_argument("--summary-out", help="Write the job summary markdown here ('-' for stdout)")
+    parser.add_argument("--issue-out", help="Write the tracking issue body here ('-' for stdout)")
+    parser.add_argument("--github-output", help="Append key=value counts here ('-' for stdout)")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    with open(args.report, encoding="utf-8") as handle:
+        report = json.load(handle)
+
+    findings = load_findings(report)
+    marker = args.marker or f"<!-- nightly-cve-scan:{args.image} -->"
+
+    _write(
+        args.summary_out,
+        render_summary(
+            findings,
+            image=args.image,
+            digest=args.digest,
+            trivy_version=args.trivy_version,
+            run_url=args.run_url,
+            gate_severity=args.gate_severity,
+        ),
+        mode="a",
+    )
+    _write(
+        args.issue_out,
+        render_issue_body(
+            findings,
+            image=args.image,
+            marker=marker,
+            digest=args.digest,
+            trivy_version=args.trivy_version,
+            run_url=args.run_url,
+            gate_severity=args.gate_severity,
+        ),
+    )
+    _write(args.github_output, render_outputs(findings), mode="a")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/trivy_report_summary.py
+++ b/scripts/trivy_report_summary.py
@@ -140,9 +140,11 @@ def render_table(findings: Sequence[Finding], max_rows: int = MAX_TABLE_ROWS) ->
 
 
 def render_counts(counts: dict[str, int]) -> list[str]:
-    present = [s for s in SEVERITIES if counts.get(s)]
-    if not present:
+    """One count row. The four graded severities always appear, so the row keeps
+    the same shape between runs; UNKNOWN only shows up when Trivy reports one."""
+    if not any(counts.get(s) for s in SEVERITIES):
         return []
+    present = [s for s in SEVERITIES if s != "UNKNOWN" or counts.get(s)]
     header = "| " + " | ".join(present) + " |"
     divider = "| " + " | ".join("---" for _ in present) + " |"
     values = "| " + " | ".join(str(counts[s]) for s in present) + " |"
@@ -206,8 +208,8 @@ def render_summary(
     lines.append(REMEDIATION_NOTE)
     lines.append("")
     lines.append(
-        "Every finding below has a fix available upstream; the scan runs with "
-        "`--ignore-unfixed`."
+        "Every finding listed above has a fix available upstream; the scan runs "
+        "with `--ignore-unfixed`."
     )
     return "\n".join(lines) + "\n"
 

--- a/tests/unit/data/trivy-clean.json
+++ b/tests/unit/data/trivy-clean.json
@@ -1,0 +1,17 @@
+{
+  "SchemaVersion": 2,
+  "ArtifactName": "docker.io/karimz1/imgcompress:nightly",
+  "ArtifactType": "container_image",
+  "Results": [
+    {
+      "Target": "docker.io/karimz1/imgcompress:nightly (debian 13.6)",
+      "Class": "os-pkgs",
+      "Type": "debian"
+    },
+    {
+      "Target": "container/venv/lib/python3.14/site-packages/flask-3.1.3.dist-info/METADATA",
+      "Class": "lang-pkgs",
+      "Type": "python-pkg"
+    }
+  ]
+}

--- a/tests/unit/data/trivy-findings.json
+++ b/tests/unit/data/trivy-findings.json
@@ -1,0 +1,69 @@
+{
+  "SchemaVersion": 2,
+  "ArtifactName": "docker.io/karimz1/imgcompress:nightly",
+  "ArtifactType": "container_image",
+  "Results": [
+    {
+      "Target": "docker.io/karimz1/imgcompress:nightly (debian 13.6)",
+      "Class": "os-pkgs",
+      "Type": "debian",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2026-3000",
+          "PkgName": "libssl3",
+          "InstalledVersion": "3.5.1-1",
+          "FixedVersion": "3.5.2-1",
+          "Status": "fixed",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2026-3000",
+          "Severity": "MEDIUM",
+          "Title": "openssl: example medium finding"
+        },
+        {
+          "VulnerabilityID": "CVE-2026-1000",
+          "PkgName": "zlib1g",
+          "InstalledVersion": "1:1.3.1-1",
+          "FixedVersion": "1:1.3.1-2",
+          "Status": "fixed",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2026-1000",
+          "Severity": "CRITICAL",
+          "Title": "zlib: example critical finding"
+        },
+        {
+          "VulnerabilityID": "CVE-2026-4000",
+          "PkgName": "tar",
+          "InstalledVersion": "1.35+dfsg-3",
+          "Status": "fixed",
+          "Severity": "LOW",
+          "Title": "tar: example low finding without a fixed version or URL"
+        }
+      ]
+    },
+    {
+      "Target": "container/venv/lib/python3.14/site-packages/pip-26.1.2.dist-info/METADATA",
+      "Class": "lang-pkgs",
+      "Type": "python-pkg",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2026-2000",
+          "PkgName": "pip",
+          "InstalledVersion": "26.1.2",
+          "FixedVersion": "26.1.3",
+          "Status": "fixed",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2026-2000",
+          "Severity": "HIGH",
+          "Title": "pip: example high finding"
+        },
+        {
+          "VulnerabilityID": "CVE-2026-2000",
+          "PkgName": "pip",
+          "InstalledVersion": "26.1.2",
+          "FixedVersion": "26.1.3",
+          "Status": "fixed",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2026-2000",
+          "Severity": "HIGH",
+          "Title": "pip: duplicate row Trivy emits for the same package"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit/test_trivy_report_summary.py
+++ b/tests/unit/test_trivy_report_summary.py
@@ -1,0 +1,237 @@
+"""Tests for the nightly CVE scan report renderer.
+
+The gate this feeds used to scrape Trivy's human-readable table for "Total: N",
+which a clean image never prints, so a green image failed the run. These tests
+pin the JSON-derived behaviour that replaced it, including the clean case.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.trivy_report_summary import (
+    count_by_severity,
+    fingerprint,
+    load_findings,
+    main,
+    render_issue_body,
+    render_counts,
+    render_outputs,
+    render_summary,
+    render_table,
+)
+
+DATA_DIR = Path(__file__).parent / "data"
+IMAGE = "docker.io/karimz1/imgcompress:nightly"
+
+
+def _load(name):
+    with (DATA_DIR / name).open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@pytest.fixture
+def clean_report():
+    return _load("trivy-clean.json")
+
+
+@pytest.fixture
+def dirty_report():
+    return _load("trivy-findings.json")
+
+
+def test_clean_report_has_no_findings(clean_report):
+    assert load_findings(clean_report) == []
+
+
+def test_clean_summary_states_the_image_is_clean(clean_report):
+    summary = render_summary(load_findings(clean_report), image=IMAGE)
+
+    assert "clean" in summary
+    assert "| Severity |" not in summary
+
+
+def test_clean_outputs_are_all_zero(clean_report):
+    outputs = render_outputs(load_findings(clean_report))
+
+    assert "critical=0" in outputs
+    assert "total=0" in outputs
+
+
+def test_duplicate_rows_are_collapsed(dirty_report):
+    findings = load_findings(dirty_report)
+
+    pip_rows = [f for f in findings if f.package == "pip"]
+    assert len(pip_rows) == 1
+    assert len(findings) == 4
+
+
+def test_findings_are_sorted_by_severity(dirty_report):
+    severities = [f.severity for f in load_findings(dirty_report)]
+
+    assert severities == ["CRITICAL", "HIGH", "MEDIUM", "LOW"]
+
+
+def test_counts_are_derived_per_severity(dirty_report):
+    counts = count_by_severity(load_findings(dirty_report))
+
+    assert counts["CRITICAL"] == 1
+    assert counts["HIGH"] == 1
+    assert counts["MEDIUM"] == 1
+    assert counts["LOW"] == 1
+
+
+def test_table_links_the_cve_when_trivy_supplies_a_url(dirty_report):
+    table = "\n".join(render_table(load_findings(dirty_report)))
+
+    assert "[CVE-2026-1000](https://avd.aquasec.com/nvd/cve-2026-1000)" in table
+
+
+def test_table_falls_back_to_plain_text_without_a_url(dirty_report):
+    table = "\n".join(render_table(load_findings(dirty_report)))
+
+    assert "| CVE-2026-4000 |" in table
+
+
+def test_table_renders_a_dash_for_a_missing_fixed_version(dirty_report):
+    row = next(
+        line
+        for line in render_table(load_findings(dirty_report))
+        if "CVE-2026-4000" in line
+    )
+
+    assert "| `-` |" in row
+
+
+def test_table_reports_omitted_rows_instead_of_truncating_silently(dirty_report):
+    lines = render_table(load_findings(dirty_report), max_rows=2)
+
+    data_rows = [line for line in lines[2:] if line.startswith("|")]
+    assert len(data_rows) == 2
+    assert any("2 further finding(s) omitted" in line for line in lines)
+
+
+def test_summary_reports_failure_when_a_critical_is_present(dirty_report):
+    summary = render_summary(load_findings(dirty_report), image=IMAGE)
+
+    assert "**Result:** failed. 1 fixable CRITICAL" in summary
+    assert "CVE-2026-1000" in summary
+
+
+def test_summary_passes_when_only_lower_severities_are_present(dirty_report):
+    findings = [f for f in load_findings(dirty_report) if f.severity != "CRITICAL"]
+
+    summary = render_summary(findings, image=IMAGE)
+
+    assert "**Result:** passed." in summary
+    assert "3 lower-severity finding(s)" in summary
+
+
+def test_summary_includes_the_scan_metadata(dirty_report):
+    summary = render_summary(
+        load_findings(dirty_report),
+        image=IMAGE,
+        digest="sha256:fada29",
+        trivy_version="0.70.0",
+        run_url="https://example.invalid/run/1",
+    )
+
+    assert f"`{IMAGE}`" in summary
+    assert "sha256:fada29" in summary
+    assert "Trivy 0.70.0" in summary
+    assert "https://example.invalid/run/1" in summary
+
+
+def test_issue_body_carries_the_marker_and_fingerprint(dirty_report):
+    findings = load_findings(dirty_report)
+    marker = f"<!-- nightly-cve-scan:{IMAGE} -->"
+
+    body = render_issue_body(findings, image=IMAGE, marker=marker)
+
+    assert body.startswith(marker)
+    assert f"<!-- fingerprint:{fingerprint(findings)} -->" in body
+
+
+def test_fingerprint_ignores_report_ordering(dirty_report):
+    findings = load_findings(dirty_report)
+
+    assert fingerprint(findings) == fingerprint(list(reversed(findings)))
+
+
+def test_fingerprint_changes_when_a_finding_appears(dirty_report):
+    findings = load_findings(dirty_report)
+
+    assert fingerprint(findings) != fingerprint(findings[1:])
+
+
+def test_outputs_are_valid_workflow_key_value_lines(dirty_report):
+    outputs = render_outputs(load_findings(dirty_report))
+    pairs = dict(line.split("=", 1) for line in outputs.strip().splitlines())
+
+    assert pairs["critical"] == "1"
+    assert pairs["high"] == "1"
+    assert pairs["total"] == "4"
+    assert len(pairs["fingerprint"]) == 16
+
+
+def test_main_writes_every_artifact(tmp_path):
+    summary = tmp_path / "summary.md"
+    issue = tmp_path / "issue-body.md"
+    outputs = tmp_path / "outputs.txt"
+
+    exit_code = main(
+        [
+            str(DATA_DIR / "trivy-findings.json"),
+            "--image",
+            IMAGE,
+            "--summary-out",
+            str(summary),
+            "--issue-out",
+            str(issue),
+            "--github-output",
+            str(outputs),
+        ]
+    )
+
+    assert exit_code == 0
+    assert "Container CVE scan" in summary.read_text(encoding="utf-8")
+    assert f"<!-- nightly-cve-scan:{IMAGE} -->" in issue.read_text(encoding="utf-8")
+    assert "critical=1" in outputs.read_text(encoding="utf-8")
+
+
+def test_main_appends_to_the_github_command_files(tmp_path):
+    """$GITHUB_STEP_SUMMARY and $GITHUB_OUTPUT are shared, append-only files."""
+    summary = tmp_path / "summary.md"
+    outputs = tmp_path / "outputs.txt"
+    summary.write_text("written by an earlier step\n", encoding="utf-8")
+    outputs.write_text("earlier=value\n", encoding="utf-8")
+
+    main(
+        [
+            str(DATA_DIR / "trivy-clean.json"),
+            "--image",
+            IMAGE,
+            "--summary-out",
+            str(summary),
+            "--github-output",
+            str(outputs),
+        ]
+    )
+
+    assert summary.read_text(encoding="utf-8").startswith("written by an earlier step")
+    assert "earlier=value" in outputs.read_text(encoding="utf-8")
+    assert "critical=0" in outputs.read_text(encoding="utf-8")
+
+
+def test_count_row_keeps_all_graded_severities(dirty_report):
+    findings = [f for f in load_findings(dirty_report) if f.severity == "MEDIUM"]
+
+    header, _, values = render_counts(count_by_severity(findings))
+
+    assert header == "| CRITICAL | HIGH | MEDIUM | LOW |"
+    assert values == "| 0 | 0 | 1 | 0 |"
+
+
+def test_count_row_is_empty_without_findings(clean_report):
+    assert render_counts(count_by_severity(load_findings(clean_report))) == []


### PR DESCRIPTION
Adds a conversion mode to the Trivy scan wrapper and a JSON report renderer for the nightly CVE scan.

- Introduces TRIVY_CONVERT_FROM to the scan script so an existing Trivy JSON report can be re-rendered into any supported format (table, SARIF, etc.) without re-scanning or requiring a local image. Validates input report exists and prints an informative message.
- Refactors the Trivy wrapper to build and pass trivy arguments dynamically, allowing both image scans and report conversion with the same entrypoint.
- Adds a new report renderer that:
  - Parses Trivy JSON, de-duplicates identical findings, and sorts by severity.
  - Emits a concise, stable markdown job summary and a tracking-issue body.
  - Produces machine-readable outputs (severity counts, total, and a stable fingerprint) for workflow gating and issue tracking.
  - Avoids brittle grepping of human-readable tables and prevents clean images from failing the job.
- Stabilizes nightly CVE scan behavior: a single JSON scan can be converted to multiple artefacts (JSON, SARIF, table) deterministically, reducing flakiness from multiple scans and enabling reliable gating and automated issue updates.

Fixes nightly CVE scan gating flakiness by producing deterministic, parseable outputs and a fingerprint for tracking unchanged results.